### PR TITLE
chore: upgrade bpmn-to-code plugin from 1.0.0 to 2.0.0

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -25,6 +25,15 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # Step 4: Run Gradle build
+      # Step 4: easy-zeebe serves as a beta-test bed for the bpmn-to-code plugin.
+      # New plugin versions are validated here before being published to the Gradle Plugin Portal,
+      # so we build and install the plugin from source into maven local.
+      - name: Install bpmn-to-code Gradle plugin from source (pre-release)
+        run: |
+          git clone --depth 1 https://github.com/emaarco/bpmn-to-code.git /tmp/bpmn-to-code
+          cd /tmp/bpmn-to-code
+          ./gradlew publishToMavenLocal
+
+      # Step 5: Run Gradle build
       - name: Run Gradle Build
         run: ./gradlew build

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ zeebe_version = "8.9.0"
 testcontainers_version = "2.0.4"
 postgres_version = "42.7.10"
 konsist_version = "0.17.3"
+bpmn_to_code_version = "2.0.0"
 
 [libraries]
 web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring_version" }
@@ -18,8 +19,10 @@ devtools = { module = "org.springframework.boot:spring-boot-devtools", version.r
 jpa = { module = 'org.springframework.boot:spring-boot-starter-data-jpa', version.ref = 'spring_version' }
 postgres = { module = 'org.postgresql:postgresql', version.ref = 'postgres_version' }
 zeebeSdk = { module = "io.camunda:camunda-spring-boot-starter", version.ref = "zeebe_version" }
+bpmnToCodeRuntime = { module = "io.github.emaarco:bpmn-to-code-runtime", version.ref = "bpmn_to_code_version" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version = "6.0.3" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin_version" }
-kotlin_logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin_logging_version" }
+kotlin_logging = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "kotlin_logging_version" }
 
 # testing
 zeebeProcessTest = { module = "io.camunda:camunda-process-test-spring", version.ref = "zeebe_version" }
@@ -45,5 +48,5 @@ kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin_ver
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin_version" }
 springframework = { id = "org.springframework.boot", version.ref = "spring_version" }
 spring-dependency = { id = "io.spring.dependency-management", version.ref = "spring_dependency_version" }
-bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version = "1.0.0" }
+bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version.ref = "bpmn_to_code_version" }
 gradleRetryTesting = { id = "org.gradle.test-retry", version = "1.6.4" }

--- a/services/common-zeebe-test/build.gradle.kts
+++ b/services/common-zeebe-test/build.gradle.kts
@@ -9,6 +9,7 @@ group = "io.miragon.example"
 version = "1.0-SNAPSHOT"
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/services/common-zeebe-test/src/main/kotlin/io/miragon/common/test/assertions/CamundaAssertExtensions.kt
+++ b/services/common-zeebe-test/src/main/kotlin/io/miragon/common/test/assertions/CamundaAssertExtensions.kt
@@ -1,0 +1,7 @@
+package io.miragon.common.test.assertions
+
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert
+import io.github.emaarco.bpmn.runtime.ElementId
+
+fun ProcessInstanceAssert.hasCompletedElements(vararg elements: ElementId): ProcessInstanceAssert =
+    hasCompletedElements(*elements.map { it.value }.toTypedArray())

--- a/services/common-zeebe/build.gradle.kts
+++ b/services/common-zeebe/build.gradle.kts
@@ -9,13 +9,16 @@ group = "io.miragon.example"
 version = "1.0-SNAPSHOT"
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
     implementation(libs.zeebeSdk)
+    api(libs.bpmnToCodeRuntime)
     implementation(libs.kotlin.logging)
     testImplementation(libs.bundles.test)
+    testRuntimeOnly(libs.junitPlatformLauncher)
 }
 
 tasks.test {

--- a/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
+++ b/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
@@ -1,5 +1,8 @@
 package io.miragon.common.zeebe.engine
 
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import io.miragon.common.zeebe.context.EventualConsistent
 import io.miragon.common.zeebe.context.StronglyConsistent
 import io.camunda.client.CamundaClient
@@ -19,13 +22,13 @@ open class ProcessEngineApi(
      */
     @StronglyConsistent
     open fun startProcess(
-        processId: String,
-        variables: Map<String, Any> = emptyMap(),
+        processId: ProcessId,
+        variables: Map<VariableName, Any> = emptyMap(),
     ): Long {
         return camundaClient.newCreateInstanceCommand()
-            .bpmnProcessId(processId)
+            .bpmnProcessId(processId.value)
             .latestVersion()
-            .variables(variables)
+            .variables(variables.mapKeys { it.key.value })
             .send()
             .join()
             .processInstanceKey
@@ -33,20 +36,20 @@ open class ProcessEngineApi(
 
     /**
      * Use this method to send a message to a running process instance.
-     * @param messageName the id of the message that should be sent
+     * @param messageName the name of the message that should be sent
      * @param correlationId an id that is used to identify the process instance
      * @param variables the variables that should be passed to the process
      */
     @StronglyConsistent
     open fun sendMessage(
-        messageName: String,
+        messageName: MessageName,
         correlationId: String,
-        variables: Map<String, Any> = emptyMap(),
+        variables: Map<VariableName, Any> = emptyMap(),
     ) {
         camundaClient.newPublishMessageCommand()
-            .messageName(messageName)
+            .messageName(messageName.value)
             .correlationKey(correlationId)
-            .variables(variables)
+            .variables(variables.mapKeys { it.key.value })
             .timeToLive(Duration.of(10, ChronoUnit.SECONDS))
             .send()
             .join()

--- a/services/common-zeebe/src/test/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApiTest.kt
+++ b/services/common-zeebe/src/test/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApiTest.kt
@@ -2,6 +2,9 @@ package io.miragon.common.zeebe.engine
 
 import io.camunda.client.CamundaClient
 import io.camunda.client.api.response.ProcessInstanceEvent
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -18,9 +21,10 @@ class ProcessEngineApiTest {
     @Test
     fun `should send message`() {
 
-        val testVariables = mapOf("dummy" to "dummy")
+        val dummyVar = VariableName.Output("dummy")
+        val testVariables: Map<VariableName, Any> = mapOf(dummyVar to "dummy")
         val correlationId = "correlationId"
-        val messageName = "messageName"
+        val messageName = MessageName("messageName")
 
         underTest.sendMessage(
             correlationId = correlationId,
@@ -30,9 +34,9 @@ class ProcessEngineApiTest {
 
         verify {
             camundaClient.newPublishMessageCommand()
-                .messageName(messageName)
+                .messageName(messageName.value)
                 .correlationKey(correlationId)
-                .variables(testVariables)
+                .variables(mapOf(dummyVar.value to "dummy"))
                 .timeToLive(Duration.of(10, ChronoUnit.SECONDS))
                 .send().join()
         }
@@ -42,20 +46,21 @@ class ProcessEngineApiTest {
     fun `should send start process message`() {
 
         // given: mock the process instance creation
-        val testVariables = mapOf("dummy" to "dummy")
-        val processId = "my-process"
+        val dummyVar = VariableName.Output("dummy")
+        val testVariables: Map<VariableName, Any> = mapOf(dummyVar to "dummy")
+        val processId = ProcessId("my-process")
         val expectedKey = 12345L
         val instanceEvent = mockk<ProcessInstanceEvent>()
-        val plainCommand = camundaClient.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion()
+        val plainCommand = camundaClient.newCreateInstanceCommand().bpmnProcessId(processId.value).latestVersion()
         every { instanceEvent.processInstanceKey } returns expectedKey
-        every { plainCommand.variables(testVariables).send().join() } returns instanceEvent
+        every { plainCommand.variables(mapOf(dummyVar.value to "dummy")).send().join() } returns instanceEvent
 
         // when: start the process
         val result = underTest.startProcess(processId = processId, variables = testVariables)
 
         // then: the process instance key should be returned
         assertThat(result).isEqualTo(expectedKey)
-        verify { plainCommand.variables(testVariables).send().join() }
+        verify { plainCommand.variables(mapOf(dummyVar.value to "dummy")).send().join() }
     }
 
 }

--- a/services/example-service/build.gradle.kts
+++ b/services/example-service/build.gradle.kts
@@ -17,6 +17,7 @@ group = "io.miragon.example"
 version = "1.0-SNAPSHOT"
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -29,6 +30,7 @@ dependencies {
     testImplementation(project(":services:common-zeebe-test"))
     testImplementation(project(":services:common-architecture-test"))
     testImplementation("com.h2database:h2")
+    testRuntimeOnly(libs.junitPlatformLauncher)
 }
 
 tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
@@ -38,7 +40,6 @@ tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 tasks.test {

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ClaimMembershipWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ClaimMembershipWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Variables
 import io.miragon.example.application.port.inbound.ClaimMembershipUseCase
 import io.miragon.example.domain.MembershipId
@@ -17,10 +17,10 @@ class ClaimMembershipWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_CLAIM_MEMBERSHIP)
+    @JobWorker(type = ServiceTasks.MIRAVELO_CLAIM_MEMBERSHIP)
     fun handle(@Variable membershipId: UUID): Map<String, Any> {
         log.debug { "Received job to claim membership for membershipId: $membershipId" }
         val hasEmptySpots = useCase.claim(MembershipId(membershipId))
-        return mapOf(Variables.HAS_EMPTY_SPOTS to hasEmptySpots)
+        return mapOf(Variables.ServiceTaskClaimMembership.HAS_EMPTY_SPOTS.value to hasEmptySpots)
     }
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.ReSendConfirmationMailUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class ReSendConfirmationMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_RE_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.MIRAVELO_RE_SEND_CONFIRMATION_MAIL)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received job to re-send confirmation mail for membershipId: $membershipId" }
         useCase.reSendConfirmationMail(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.RevokeClaimUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class RevokeClaimWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_REVOKE_CLAIM)
+    @JobWorker(type = ServiceTasks.MIRAVELO_REVOKE_CLAIM)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received compensation job to revoke claim for membershipId: $membershipId" }
         useCase.revokeClaim(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.RevokeMembershipRequestUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class RevokeMembershipRequestWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_REVOKE_MEMBERSHIP_REQUEST)
+    @JobWorker(type = ServiceTasks.MIRAVELO_REVOKE_MEMBERSHIP_REQUEST)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received job to revoke membership request for membershipId: $membershipId" }
         useCase.revokeMembershipRequest(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendConfirmationMailWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendConfirmationMailWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.SendConfirmationMailUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class SendConfirmationMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.MIRAVELO_SEND_CONFIRMATION_MAIL)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received job to send confirmation mail for membershipId: $membershipId" }
         useCase.sendConfirmationMail(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendRejectionMailWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendRejectionMailWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.SendRejectionMailUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class SendRejectionMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_SEND_REJECTION_MAIL)
+    @JobWorker(type = ServiceTasks.MIRAVELO_SEND_REJECTION_MAIL)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received job to send rejection mail for membershipId: $membershipId" }
         useCase.sendRejectionMail(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendWelcomeMailWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/SendWelcomeMailWorker.kt
@@ -2,7 +2,7 @@ package io.miragon.example.adapter.inbound.zeebe
 
 import io.camunda.client.annotation.JobWorker
 import io.camunda.client.annotation.Variable
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.ServiceTasks
 import io.miragon.example.application.port.inbound.SendWelcomeMailUseCase
 import io.miragon.example.domain.MembershipId
 import mu.KotlinLogging
@@ -16,7 +16,7 @@ class SendWelcomeMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.MIRAVELO_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.MIRAVELO_SEND_WELCOME_MAIL)
     fun handle(@Variable membershipId: UUID) {
         log.debug { "Received job to send welcome mail for membershipId: $membershipId" }
         useCase.sendWelcomeMail(MembershipId(membershipId))

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
@@ -18,7 +18,7 @@ class MembershipProcessAdapter(
         engineApi.sendMessage(
             messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_REQUESTED,
             correlationId = id.value.toString(),
-            variables = mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to id.value.toString()),
+            variables = mapOf(MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID to id.value.toString()),
         )
     }
 
@@ -38,9 +38,9 @@ class MembershipProcessAdapter(
         return camundaClient.newUserTaskSearchRequest()
             .filter { filter ->
                 filter.state(UserTaskState.CREATED)
-                filter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP)
+                filter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP.value)
                 filter.processInstanceVariables(
-                    mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to id.value.toString())
+                    mapOf(MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID.value to id.value.toString())
                 )
             }
             .send()

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
@@ -3,68 +3,95 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.BpmnTimer
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.SignalName
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object MiraveloMembershipProcessApi {
-  const val PROCESS_ID: String = "miravelo-membership"
+  val PROCESS_ID: ProcessId = ProcessId("miravelo-membership")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val END_EVENT_MAIL_SENT_AGAIN: String = "endEvent_MailSentAgain"
+    val END_EVENT_MAIL_SENT_AGAIN: ElementId = ElementId("endEvent_MailSentAgain")
 
-    const val END_EVENT_MEMBERSHIP_ACTIVATED: String = "endEvent_MembershipActivated"
+    val END_EVENT_MEMBERSHIP_ACTIVATED: ElementId = ElementId("endEvent_MembershipActivated")
 
-    const val END_EVENT_MEMBERSHIP_CONFIRMED: String = "endEvent_MembershipConfirmed"
+    val END_EVENT_MEMBERSHIP_CONFIRMED: ElementId = ElementId("endEvent_MembershipConfirmed")
 
-    const val END_EVENT_MEMBERSHIP_DECLINED: String = "endEvent_MembershipDeclined"
+    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_MembershipDeclined")
 
-    const val END_EVENT_MEMBERSHIP_REJECTED: String = "endEvent_MembershipRejected"
+    val END_EVENT_MEMBERSHIP_REJECTED: ElementId = ElementId("endEvent_MembershipRejected")
 
-    const val EVENT_CLAIM_COMPENSATION: String = "event_ClaimCompensation"
+    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_ClaimCompensation")
 
-    const val EVENT_CONFIRMATION_DEADLINE_PASSED: String = "event_ConfirmationDeadlinePassed"
+    val EVENT_CONFIRMATION_DEADLINE_PASSED: ElementId =
+        ElementId("event_ConfirmationDeadlinePassed")
 
-    const val EVENT_CONFIRMATION_REJECTED: String = "event_ConfirmationRejected"
+    val EVENT_CONFIRMATION_REJECTED: ElementId = ElementId("event_ConfirmationRejected")
 
-    const val EVENT_REMINDER_DUE: String = "event_ReminderDue"
+    val EVENT_REMINDER_DUE: ElementId = ElementId("event_ReminderDue")
 
-    const val GATEWAY_HAS_EMPTY_SPOTS: String = "gateway_HasEmptySpots"
+    val GATEWAY_HAS_EMPTY_SPOTS: ElementId = ElementId("gateway_HasEmptySpots")
 
-    const val SERVICE_TASK_CLAIM_MEMBERSHIP: String = "serviceTask_ClaimMembership"
+    val SERVICE_TASK_CLAIM_MEMBERSHIP: ElementId = ElementId("serviceTask_ClaimMembership")
 
-    const val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: String =
-        "serviceTask_ReSendConfirmationMail"
+    val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("serviceTask_ReSendConfirmationMail")
 
-    const val SERVICE_TASK_REVOKE_CLAIM: String = "serviceTask_RevokeClaim"
+    val SERVICE_TASK_REVOKE_CLAIM: ElementId = ElementId("serviceTask_RevokeClaim")
 
-    const val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: String =
-        "serviceTask_RevokeMembershipRequest"
+    val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: ElementId =
+        ElementId("serviceTask_RevokeMembershipRequest")
 
-    const val SERVICE_TASK_SEND_CONFIRMATION_MAIL: String =
-        "serviceTask_SendConfirmationMail"
+    val SERVICE_TASK_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("serviceTask_SendConfirmationMail")
 
-    const val SERVICE_TASK_SEND_REJECTION_MAIL: String = "serviceTask_SendRejectionMail"
+    val SERVICE_TASK_SEND_REJECTION_MAIL: ElementId =
+        ElementId("serviceTask_SendRejectionMail")
 
-    const val SERVICE_TASK_SEND_WELCOME_MAIL: String = "serviceTask_SendWelcomeMail"
+    val SERVICE_TASK_SEND_WELCOME_MAIL: ElementId = ElementId("serviceTask_SendWelcomeMail")
 
-    const val START_EVENT_CONFIRMATION_REQUIRED: String = "startEvent_ConfirmationRequired"
+    val START_EVENT_CONFIRMATION_REQUIRED: ElementId =
+        ElementId("startEvent_ConfirmationRequired")
 
-    const val START_EVENT_MEMBERSHIP_REQUESTED: String = "startEvent_MembershipRequested"
+    val START_EVENT_MEMBERSHIP_REQUESTED: ElementId =
+        ElementId("startEvent_MembershipRequested")
 
-    const val SUB_PROCESS_CONFIRM_MEMBERSHIP: String = "subProcess_ConfirmMembership"
+    val SUB_PROCESS_CONFIRM_MEMBERSHIP: ElementId = ElementId("subProcess_ConfirmMembership")
 
-    const val USER_TASK_CONFIRM_MEMBERSHIP: String = "userTask_ConfirmMembership"
+    val USER_TASK_CONFIRM_MEMBERSHIP: ElementId = ElementId("userTask_ConfirmMembership")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MIRAVELO_CONFIRMATION_REJECTED: String = "miravelo.confirmationRejected"
+    val MIRAVELO_CONFIRMATION_REJECTED: MessageName =
+        MessageName("miravelo.confirmationRejected")
 
-    const val MIRAVELO_MEMBERSHIP_REQUESTED: String = "miravelo.membershipRequested"
+    val MIRAVELO_MEMBERSHIP_REQUESTED: MessageName =
+        MessageName("miravelo.membershipRequested")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val MIRAVELO_CLAIM_MEMBERSHIP: String = "miravelo.claimMembership"
 
     const val MIRAVELO_RE_SEND_CONFIRMATION_MAIL: String = "miravelo.reSendConfirmationMail"
@@ -84,20 +111,326 @@ object MiraveloMembershipProcessApi {
     val EVENT_CONFIRMATION_DEADLINE_PASSED: BpmnTimer = BpmnTimer("Duration", "P3DT12H")
 
     val EVENT_REMINDER_DUE: BpmnTimer = BpmnTimer("Cycle", "R/P1D")
+  }
 
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
+  object Compensations {
+    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_MembershipDeclined")
+
+    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_ClaimCompensation")
   }
 
   object Signals {
-    const val MIRAVELO_MEMBERSHIP_ACTIVATED: String = "miravelo.membershipActivated"
+    val MIRAVELO_MEMBERSHIP_ACTIVATED: SignalName =
+        SignalName("miravelo.membershipActivated")
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
   object Variables {
-    const val HAS_EMPTY_SPOTS: String = "hasEmptySpots"
+    object ServiceTaskClaimMembership {
+      val HAS_EMPTY_SPOTS: VariableName.Output = VariableName.Output("hasEmptySpots")
+    }
 
-    const val MEMBERSHIP_ID: String = "membershipId"
+    object StartEventMembershipRequested {
+      val MEMBERSHIP_ID: VariableName.Output = VariableName.Output("membershipId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_CLAIM_TO_GATEWAY: BpmnFlow = BpmnFlow(
+          id = "Flow_claim_to_gateway",
+          sourceRef = "serviceTask_ClaimMembership",
+          targetRef = "gateway_HasEmptySpots",
+        )
+
+    val FLOW_CONFIRMATION_MAIL_TO_USER_TASK: BpmnFlow = BpmnFlow(
+          id = "Flow_confirmationMail_to_userTask",
+          sourceRef = "serviceTask_SendConfirmationMail",
+          targetRef = "userTask_ConfirmMembership",
+        )
+
+    val FLOW_NO_SPOTS: BpmnFlow = BpmnFlow(
+          id = "Flow_no_spots",
+          name = "No",
+          sourceRef = "gateway_HasEmptySpots",
+          targetRef = "serviceTask_SendRejectionMail",
+          isDefault = true,
+        )
+
+    val FLOW_RE_SEND_TO_END: BpmnFlow = BpmnFlow(
+          id = "Flow_reSend_to_end",
+          sourceRef = "serviceTask_ReSendConfirmationMail",
+          targetRef = "endEvent_MailSentAgain",
+        )
+
+    val FLOW_REJECTED_TO_REVOKE: BpmnFlow = BpmnFlow(
+          id = "Flow_rejected_to_revoke",
+          sourceRef = "event_ConfirmationRejected",
+          targetRef = "serviceTask_RevokeMembershipRequest",
+        )
+
+    val FLOW_REJECTION_TO_END: BpmnFlow = BpmnFlow(
+          id = "Flow_rejection_to_end",
+          sourceRef = "serviceTask_SendRejectionMail",
+          targetRef = "endEvent_MembershipRejected",
+        )
+
+    val FLOW_REVOKE_TO_DECLINED: BpmnFlow = BpmnFlow(
+          id = "Flow_revoke_to_declined",
+          sourceRef = "serviceTask_RevokeMembershipRequest",
+          targetRef = "endEvent_MembershipDeclined",
+        )
+
+    val FLOW_START_TO_CLAIM: BpmnFlow = BpmnFlow(
+          id = "Flow_start_to_claim",
+          sourceRef = "startEvent_MembershipRequested",
+          targetRef = "serviceTask_ClaimMembership",
+        )
+
+    val FLOW_SUB_PROCESS_TO_WELCOME: BpmnFlow = BpmnFlow(
+          id = "Flow_subProcess_to_welcome",
+          sourceRef = "subProcess_ConfirmMembership",
+          targetRef = "serviceTask_SendWelcomeMail",
+        )
+
+    val FLOW_SUB_START_TO_CONFIRMATION_MAIL: BpmnFlow = BpmnFlow(
+          id = "Flow_subStart_to_confirmationMail",
+          sourceRef = "startEvent_ConfirmationRequired",
+          targetRef = "serviceTask_SendConfirmationMail",
+        )
+
+    val FLOW_TIMEOUT_TO_REVOKE: BpmnFlow = BpmnFlow(
+          id = "Flow_timeout_to_revoke",
+          sourceRef = "event_ConfirmationDeadlinePassed",
+          targetRef = "serviceTask_RevokeMembershipRequest",
+        )
+
+    val FLOW_TIMER_TO_RE_SEND: BpmnFlow = BpmnFlow(
+          id = "Flow_timer_to_reSend",
+          sourceRef = "event_ReminderDue",
+          targetRef = "serviceTask_ReSendConfirmationMail",
+        )
+
+    val FLOW_USER_TASK_TO_SUB_END: BpmnFlow = BpmnFlow(
+          id = "Flow_userTask_to_subEnd",
+          sourceRef = "userTask_ConfirmMembership",
+          targetRef = "endEvent_MembershipConfirmed",
+        )
+
+    val FLOW_WELCOME_TO_ACTIVATED: BpmnFlow = BpmnFlow(
+          id = "Flow_welcome_to_activated",
+          sourceRef = "serviceTask_SendWelcomeMail",
+          targetRef = "endEvent_MembershipActivated",
+        )
+
+    val FLOW_YES_SPOTS: BpmnFlow = BpmnFlow(
+          id = "Flow_yes_spots",
+          name = "Yes",
+          sourceRef = "gateway_HasEmptySpots",
+          targetRef = "subProcess_ConfirmMembership",
+          condition = "=hasEmptySpots",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val END_EVENT_MAIL_SENT_AGAIN: BpmnRelations = BpmnRelations(
+          name = "Mail sent again",
+          previousElements = listOf("serviceTask_ReSendConfirmationMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_MEMBERSHIP_ACTIVATED: BpmnRelations = BpmnRelations(
+          name = "Membership activated",
+          previousElements = listOf("serviceTask_SendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_MEMBERSHIP_CONFIRMED: BpmnRelations = BpmnRelations(
+          name = "Membership confirmed",
+          previousElements = listOf("userTask_ConfirmMembership"),
+          followingElements = emptyList(),
+          parentId = "subProcess_ConfirmMembership",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_MEMBERSHIP_DECLINED: BpmnRelations = BpmnRelations(
+          name = "Membership declined",
+          previousElements = listOf("serviceTask_RevokeMembershipRequest"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_MEMBERSHIP_REJECTED: BpmnRelations = BpmnRelations(
+          name = "Membership rejected",
+          previousElements = listOf("serviceTask_SendRejectionMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val EVENT_CLAIM_COMPENSATION: BpmnRelations = BpmnRelations(
+          previousElements = emptyList(),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = "serviceTask_ClaimMembership",
+          attachedElements = emptyList(),
+        )
+
+    val EVENT_CONFIRMATION_DEADLINE_PASSED: BpmnRelations = BpmnRelations(
+          name = "Deadline passed",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_RevokeMembershipRequest"),
+          parentId = null,
+          attachedToRef = "subProcess_ConfirmMembership",
+          attachedElements = emptyList(),
+        )
+
+    val EVENT_CONFIRMATION_REJECTED: BpmnRelations = BpmnRelations(
+          name = "Confirmation rejected",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_RevokeMembershipRequest"),
+          parentId = null,
+          attachedToRef = "subProcess_ConfirmMembership",
+          attachedElements = emptyList(),
+        )
+
+    val EVENT_REMINDER_DUE: BpmnRelations = BpmnRelations(
+          name = "Reminder due",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_ReSendConfirmationMail"),
+          parentId = null,
+          attachedToRef = "subProcess_ConfirmMembership",
+          attachedElements = emptyList(),
+        )
+
+    val GATEWAY_HAS_EMPTY_SPOTS: BpmnRelations = BpmnRelations(
+          name = "Has empty spots?",
+          previousElements = listOf("serviceTask_ClaimMembership"),
+          followingElements = listOf("subProcess_ConfirmMembership", "serviceTask_SendRejectionMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_CLAIM_MEMBERSHIP: BpmnRelations = BpmnRelations(
+          name = "Claim Membership",
+          previousElements = listOf("startEvent_MembershipRequested"),
+          followingElements = listOf("gateway_HasEmptySpots"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("event_ClaimCompensation"),
+        )
+
+    val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Re-Send Confirmation Mail",
+          previousElements = listOf("event_ReminderDue"),
+          followingElements = listOf("endEvent_MailSentAgain"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_REVOKE_CLAIM: BpmnRelations = BpmnRelations(
+          name = "Revoke Claim",
+          previousElements = emptyList(),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: BpmnRelations = BpmnRelations(
+          name = "Revoke Membership Request",
+          previousElements = listOf("event_ConfirmationDeadlinePassed", "event_ConfirmationRejected"),
+          followingElements = listOf("endEvent_MembershipDeclined"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Confirmation Mail",
+          previousElements = listOf("startEvent_ConfirmationRequired"),
+          followingElements = listOf("userTask_ConfirmMembership"),
+          parentId = "subProcess_ConfirmMembership",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_SEND_REJECTION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Rejection Mail",
+          previousElements = listOf("gateway_HasEmptySpots"),
+          followingElements = listOf("endEvent_MembershipRejected"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome Mail",
+          previousElements = listOf("subProcess_ConfirmMembership"),
+          followingElements = listOf("endEvent_MembershipActivated"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_CONFIRMATION_REQUIRED: BpmnRelations = BpmnRelations(
+          name = "Confirmation required",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_SendConfirmationMail"),
+          parentId = "subProcess_ConfirmMembership",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_MEMBERSHIP_REQUESTED: BpmnRelations = BpmnRelations(
+          name = "Membership requested",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_ClaimMembership"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SUB_PROCESS_CONFIRM_MEMBERSHIP: BpmnRelations = BpmnRelations(
+          name = "Confirm Membership",
+          previousElements = listOf("gateway_HasEmptySpots"),
+          followingElements = listOf("serviceTask_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("event_ReminderDue", "event_ConfirmationRejected", "event_ConfirmationDeadlinePassed"),
+        )
+
+    val USER_TASK_CONFIRM_MEMBERSHIP: BpmnRelations = BpmnRelations(
+          name = "Confirm Membership",
+          previousElements = listOf("serviceTask_SendConfirmationMail"),
+          followingElements = listOf("endEvent_MembershipConfirmed"),
+          parentId = "subProcess_ConfirmMembership",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/ClaimMembershipWorkerTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/ClaimMembershipWorkerTest.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.inbound.zeebe
 
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Variables.HAS_EMPTY_SPOTS
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Variables.ServiceTaskClaimMembership
 import io.miragon.example.application.port.inbound.ClaimMembershipUseCase
 import io.miragon.example.domain.MembershipId
 import io.mockk.confirmVerified
@@ -28,7 +28,7 @@ class ClaimMembershipWorkerTest {
         val result = underTest.handle(membershipId)
 
         // Then
-        assertThat(result).containsExactly(entry(HAS_EMPTY_SPOTS, true))
+        assertThat(result).containsExactly(entry(ServiceTaskClaimMembership.HAS_EMPTY_SPOTS.value, true))
         verify(exactly = 1) { useCase.claim(MembershipId(membershipId)) }
         confirmVerified(useCase)
     }
@@ -44,7 +44,7 @@ class ClaimMembershipWorkerTest {
         val result = underTest.handle(membershipId)
 
         // Then
-        assertThat(result).containsExactly(entry(HAS_EMPTY_SPOTS, false))
+        assertThat(result).containsExactly(entry(ServiceTaskClaimMembership.HAS_EMPTY_SPOTS.value, false))
         verify(exactly = 1) { useCase.claim(MembershipId(membershipId)) }
         confirmVerified(useCase)
     }

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
@@ -9,6 +9,7 @@ import io.camunda.client.api.search.filter.UserTaskFilter
 import io.camunda.client.api.search.request.UserTaskSearchRequest
 import io.camunda.client.api.search.response.SearchResponse
 import io.camunda.client.api.search.response.UserTask
+import io.github.emaarco.bpmn.runtime.VariableName
 import io.miragon.common.zeebe.engine.ProcessEngineApi
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi
 import io.miragon.example.domain.MembershipId
@@ -37,7 +38,7 @@ class MembershipProcessAdapterTest {
 
         // Given
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
-        val expectedVariables = mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to membershipId.value.toString())
+        val expectedVariables: Map<VariableName, Any> = mapOf(MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID to membershipId.value.toString())
         every { engineApi.sendMessage(any(), any(), any()) } just Runs
 
         // When
@@ -84,10 +85,10 @@ class MembershipProcessAdapterTest {
 
         // Then: the adapter applied the expected filter and completed the task it found
         verify { capturedFilter.state(UserTaskState.CREATED) }
-        verify { capturedFilter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP) }
+        verify { capturedFilter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP.value) }
         verify {
             capturedFilter.processInstanceVariables(
-                mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to membershipId.value.toString())
+                mapOf(MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID.value to membershipId.value.toString())
             )
         }
         verify { camundaClient.newCompleteUserTaskCommand(expectedUserTaskKey) }

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
@@ -6,6 +6,7 @@ import io.camunda.process.test.api.CamundaAssert
 import io.camunda.process.test.api.CamundaProcessTestContext
 import io.camunda.process.test.api.CamundaSpringProcessTest
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors
+import io.miragon.common.test.assertions.hasCompletedElements
 import io.miragon.common.test.config.TestProcessEngineConfiguration
 import io.miragon.example.adapter.outbound.zeebe.MembershipProcessAdapter
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Elements
@@ -97,7 +98,7 @@ class MiraveloMembershipProcessTest {
         processPort.registerMembership(MembershipId(membershipId))
         val instanceKey = awaitProcessInstance(membershipId)
         awaitUserTaskCreated(instanceKey)
-        processTestContext.completeUserTask(Elements.USER_TASK_CONFIRM_MEMBERSHIP)
+        processTestContext.completeUserTask(Elements.USER_TASK_CONFIRM_MEMBERSHIP.value)
 
         // then - process completes, welcome mail is sent, activation signal thrown
         val instance = ProcessInstanceSelectors.byKey(instanceKey)
@@ -263,7 +264,7 @@ class MiraveloMembershipProcessTest {
             .untilAsserted {
                 val instances = camundaClient.newProcessInstanceSearchRequest()
                     .filter { filter ->
-                        filter.processDefinitionId(MiraveloMembershipProcessApi.PROCESS_ID)
+                        filter.processDefinitionId(MiraveloMembershipProcessApi.PROCESS_ID.value)
                     }
                     .send()
                     .join()
@@ -282,7 +283,7 @@ class MiraveloMembershipProcessTest {
                 val tasks = camundaClient.newUserTaskSearchRequest()
                     .filter { filter ->
                         filter.processInstanceKey(processInstanceKey)
-                        filter.elementId(Elements.USER_TASK_CONFIRM_MEMBERSHIP)
+                        filter.elementId(Elements.USER_TASK_CONFIRM_MEMBERSHIP.value)
                     }
                     .send()
                     .join()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "easy-zeebe"
 
 include("services:example-service")


### PR DESCRIPTION
## Summary
- Adds `mavenLocal()` to `pluginManagement` in `settings.gradle.kts` so Gradle resolves the v2 plugin locally
- Bumps `bpmn-to-code-gradle` plugin version from `1.0.0` to `2.0.0` and removes the removed `useVersioning` property
- Regenerates `NewsletterSubscriptionProcessApi` with the v2 shape: `TaskTypes` → `ServiceTasks`, `Variables` nested per-element, new `Flows`/`Relations` objects, `BpmnTimer` moved to a standalone `types` package
- Migrates all source references: workers (`TaskTypes` → `ServiceTasks`), adapters and tests (`Variables.SUBSCRIPTION_ID` → `Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID`, `Variables.WELCOME_MAIL_SENT` → `Variables.ServiceTaskSendWelcomeMail.WELCOME_MAIL_SENT`)

## Test plan
- [x] `./gradlew :services:example-service:generateBpmnModelApi` succeeds
- [x] `./gradlew :services:example-service:compileKotlin` succeeds (no unresolved references)
- [x] `./gradlew :services:example-service:test` passes (all tests green)