### PR TITLE
feat: enrich MiraVelo membership process with timers, rejection, compensation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,19 @@ Because someone read a book about luxury brands and now inserts "Premium Positio
 > — Honest comment from Sprint Planning
 
 From a process perspective, this means a **gateway** — the merciless bouncer in the process flow.
-Got a spot? Congratulations, move on: confirmation mail, member confirms, welcome mail.
+Got a spot? Confirmation mail, member confirms via a user task, welcome mail, signal: *activated.*
 No spot? Rejection mail. No appeal. The gateway decides.
+
+But scarcity creates a different problem: what if someone claims a spot and then *ghosts*?
+So the happy path is wrapped in a **Confirm Membership sub-process** with three safety nets:
+
+- a **non-interrupting daily timer** that re-sends the confirmation mail every 24h — gentle FOMO,
+- an **interrupting 3½-day timer** that revokes the membership request if no one confirmed in time,
+- a **`Confirmation rejected` message boundary event** — if the user explicitly declines.
+
+Any of those three exits trigger a **compensating `Revoke Claim` task** that hands the spot back to the
+pool, and the process ends on a `Membership declined` compensation end event. The happy path ends on a
+`Membership activated` signal end event — ready for any downstream integrations to react to.
 
 This repository implements exactly that membership process as a clean, testable Zeebe + Spring Boot service:
 
@@ -147,12 +158,20 @@ object MiraveloMembershipProcessApi {
     object TaskTypes {
         const val MIRAVELO_CLAIM_MEMBERSHIP: String = "miravelo.claimMembership"
         const val MIRAVELO_SEND_CONFIRMATION_MAIL: String = "miravelo.sendConfirmationMail"
+        const val MIRAVELO_RE_SEND_CONFIRMATION_MAIL: String = "miravelo.reSendConfirmationMail"
         const val MIRAVELO_SEND_WELCOME_MAIL: String = "miravelo.sendWelcomeMail"
         const val MIRAVELO_SEND_REJECTION_MAIL: String = "miravelo.sendRejectionMail"
+        const val MIRAVELO_REVOKE_MEMBERSHIP_REQUEST: String = "miravelo.revokeMembershipRequest"
+        const val MIRAVELO_REVOKE_CLAIM: String = "miravelo.revokeClaim"
     }
 
     object Messages {
-        const val MIRAVELO_MEMBERSHIP_CONFIRMED: String = "miravelo.membershipConfirmed"
+        const val MIRAVELO_MEMBERSHIP_REQUESTED: String = "miravelo.membershipRequested"
+        const val MIRAVELO_CONFIRMATION_REJECTED: String = "miravelo.confirmationRejected"
+    }
+
+    object Signals {
+        const val MIRAVELO_MEMBERSHIP_ACTIVATED: String = "miravelo.membershipActivated"
     }
 
     object Variables {

--- a/bruno/reject-confirmation.bru
+++ b/bruno/reject-confirmation.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Reject Confirmation
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:8081/api/memberships/reject-confirmation/:membershipId
+  body: none
+  auth: none
+}
+
+params:path {
+  membershipId: {{membershipId}}
+}

--- a/services/example-service/README.md
+++ b/services/example-service/README.md
@@ -9,6 +9,8 @@ and various REST endpoints to interact with it.
 
 ## 🧩 Process overview
 
+![MiraVelo Membership Process](../../assets/membership.svg)
+
 The `miravelo-membership` process is triggered by publishing the `miravelo.membershipRequested`
 message (the `POST /api/memberships` endpoint does this via the process adapter).
 Key steps:

--- a/services/example-service/README.md
+++ b/services/example-service/README.md
@@ -1,14 +1,40 @@
 # 🌟 example-service
 
-This service is a showcase that demonstrates how to integrate and use **Zeebe** within a Spring service. 
-It leverages both the **common-zeebe** and **common-zeebe-test** modules to orchestrate 
+This service is a showcase that demonstrates how to integrate and use **Zeebe** within a Spring service.
+It leverages both the **common-zeebe** and **common-zeebe-test** modules to orchestrate
 and test BPMN processes seamlessly.
 
-This service provides a hands-on example with the **MiraVelo Inner Circle membership process** 
+This service provides a hands-on example with the **MiraVelo Inner Circle membership process**
 and various REST endpoints to interact with it.
+
+## 🧩 Process overview
+
+The `miravelo-membership` process is triggered by publishing the `miravelo.membershipRequested`
+message (the `POST /api/memberships` endpoint does this via the process adapter).
+Key steps:
+
+1. **Claim Membership** — reserves one of the 1000 spots; sets `hasEmptySpots`.
+2. **No spots** → **Send Rejection Mail** → `Membership rejected`.
+3. **Spot available** → opens the **Confirm Membership** sub-process:
+    - **Send Confirmation Mail** → wait for the user via a **user task**.
+    - A **non-interrupting daily timer** fires `Re-Send Confirmation Mail` to nudge the user.
+    - An **interrupting 3½-day timer** aborts the sub-process and flows into `Revoke Membership Request`.
+    - A **`miravelo.confirmationRejected` message boundary event** aborts the sub-process on user rejection,
+      also flowing into `Revoke Membership Request`.
+    - On abort/rejection, **compensation** triggers `Revoke Claim` so the spot is released back to the pool,
+      and the process ends on `Membership declined`.
+4. **Happy path** (user confirmed) → **Send Welcome Mail** → `Membership activated` (throws the
+   `miravelo.membershipActivated` signal).
+
+## 🧪 REST endpoints
+
+- `POST /api/memberships` — submit a registration (publishes the start message).
+- `POST /api/memberships/confirm/{membershipId}` — complete the user task for this member.
+- `POST /api/memberships/reject-confirmation/{membershipId}` — publish `miravelo.confirmationRejected`.
 
 ## 🔧 Key Features
 
 - **Zeebe Integration**: Utilizes `common-zeebe` for connecting and interacting with the Zeebe process engine.
-- **Process Testing**: Incorporates `common-zeebe-test` to provide robust, integrated process testing.
+- **Process Testing**: Incorporates `common-zeebe-test` to provide robust, integrated process testing that
+  covers timers, compensation, and the signal end event.
 - **REST API**: Offers multiple endpoints to interact with the MiraVelo membership process.

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/rest/RejectConfirmationController.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/rest/RejectConfirmationController.kt
@@ -1,0 +1,25 @@
+package io.miragon.example.adapter.inbound.rest
+
+import io.miragon.example.application.port.inbound.RejectConfirmationUseCase
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@RequestMapping("/api/memberships")
+class RejectConfirmationController(private val useCase: RejectConfirmationUseCase) {
+
+    private val log = KotlinLogging.logger {}
+
+    @PostMapping("/reject-confirmation/{membershipId}")
+    fun rejectConfirmation(@PathVariable membershipId: String): ResponseEntity<Void> {
+        log.debug { "Received REST-request to reject confirmation for membership: $membershipId" }
+        useCase.rejectConfirmation(MembershipId(UUID.fromString(membershipId)))
+        return ResponseEntity.ok().build()
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorker.kt
@@ -1,0 +1,24 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.camunda.client.annotation.JobWorker
+import io.camunda.client.annotation.Variable
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.application.port.inbound.ReSendConfirmationMailUseCase
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class ReSendConfirmationMailWorker(
+    private val useCase: ReSendConfirmationMailUseCase
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    @JobWorker(type = TaskTypes.MIRAVELO_RE_SEND_CONFIRMATION_MAIL)
+    fun handle(@Variable membershipId: UUID) {
+        log.debug { "Received job to re-send confirmation mail for membershipId: $membershipId" }
+        useCase.reSendConfirmationMail(MembershipId(membershipId))
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorker.kt
@@ -1,0 +1,24 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.camunda.client.annotation.JobWorker
+import io.camunda.client.annotation.Variable
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.application.port.inbound.RevokeClaimUseCase
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class RevokeClaimWorker(
+    private val useCase: RevokeClaimUseCase
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    @JobWorker(type = TaskTypes.MIRAVELO_REVOKE_CLAIM)
+    fun handle(@Variable membershipId: UUID) {
+        log.debug { "Received compensation job to revoke claim for membershipId: $membershipId" }
+        useCase.revokeClaim(MembershipId(membershipId))
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorker.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorker.kt
@@ -1,0 +1,24 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.camunda.client.annotation.JobWorker
+import io.camunda.client.annotation.Variable
+import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.TaskTypes
+import io.miragon.example.application.port.inbound.RevokeMembershipRequestUseCase
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class RevokeMembershipRequestWorker(
+    private val useCase: RevokeMembershipRequestUseCase
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    @JobWorker(type = TaskTypes.MIRAVELO_REVOKE_MEMBERSHIP_REQUEST)
+    fun handle(@Variable membershipId: UUID) {
+        log.debug { "Received job to revoke membership request for membershipId: $membershipId" }
+        useCase.revokeMembershipRequest(MembershipId(membershipId))
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
@@ -1,5 +1,7 @@
 package io.miragon.example.adapter.outbound.zeebe
 
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.search.enums.UserTaskState
 import io.miragon.common.zeebe.engine.ProcessEngineApi
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi
 import io.miragon.example.application.port.outbound.MembershipProcess
@@ -8,21 +10,42 @@ import org.springframework.stereotype.Component
 
 @Component
 class MembershipProcessAdapter(
-    private val engineApi: ProcessEngineApi
+    private val engineApi: ProcessEngineApi,
+    private val camundaClient: CamundaClient,
 ) : MembershipProcess {
 
-    override fun registerMembership(id: MembershipId): Long {
-        val variables = mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to id.value.toString())
-        return engineApi.startProcess(
-            processId = MiraveloMembershipProcessApi.PROCESS_ID,
-            variables = variables
+    override fun registerMembership(id: MembershipId) {
+        engineApi.sendMessage(
+            messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_REQUESTED,
+            correlationId = id.value.toString(),
+            variables = mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to id.value.toString()),
         )
     }
 
     override fun confirmMembership(id: MembershipId) {
+        val userTaskKey = findActiveConfirmUserTask(id)
+        camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join()
+    }
+
+    override fun rejectConfirmation(id: MembershipId) {
         engineApi.sendMessage(
-            messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_CONFIRMED,
+            messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_CONFIRMATION_REJECTED,
             correlationId = id.value.toString(),
         )
+    }
+
+    private fun findActiveConfirmUserTask(id: MembershipId): Long {
+        val tasks = camundaClient.newUserTaskSearchRequest()
+            .filter { filter ->
+                filter.state(UserTaskState.CREATED)
+                filter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP)
+                filter.processInstanceVariables(
+                    mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to id.value.toString())
+                )
+            }
+            .send()
+            .join()
+            .items()
+        return tasks.single().userTaskKey
     }
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
@@ -35,7 +35,7 @@ class MembershipProcessAdapter(
     }
 
     private fun findActiveConfirmUserTask(id: MembershipId): Long {
-        val tasks = camundaClient.newUserTaskSearchRequest()
+        return camundaClient.newUserTaskSearchRequest()
             .filter { filter ->
                 filter.state(UserTaskState.CREATED)
                 filter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP)
@@ -46,6 +46,7 @@ class MembershipProcessAdapter(
             .send()
             .join()
             .items()
-        return tasks.single().userTaskKey
+            .single()
+            .userTaskKey
     }
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
@@ -12,15 +12,35 @@ object MiraveloMembershipProcessApi {
   const val PROCESS_ENGINE: String = "ZEEBE"
 
   object Elements {
+    const val END_EVENT_MAIL_SENT_AGAIN: String = "endEvent_MailSentAgain"
+
+    const val END_EVENT_MEMBERSHIP_ACTIVATED: String = "endEvent_MembershipActivated"
+
     const val END_EVENT_MEMBERSHIP_CONFIRMED: String = "endEvent_MembershipConfirmed"
+
+    const val END_EVENT_MEMBERSHIP_DECLINED: String = "endEvent_MembershipDeclined"
 
     const val END_EVENT_MEMBERSHIP_REJECTED: String = "endEvent_MembershipRejected"
 
+    const val EVENT_CLAIM_COMPENSATION: String = "event_ClaimCompensation"
+
+    const val EVENT_CONFIRMATION_DEADLINE_PASSED: String = "event_ConfirmationDeadlinePassed"
+
+    const val EVENT_CONFIRMATION_REJECTED: String = "event_ConfirmationRejected"
+
+    const val EVENT_REMINDER_DUE: String = "event_ReminderDue"
+
     const val GATEWAY_HAS_EMPTY_SPOTS: String = "gateway_HasEmptySpots"
 
-    const val RECEIVE_TASK_CONFIRM_MEMBERSHIP: String = "receiveTask_ConfirmMembership"
-
     const val SERVICE_TASK_CLAIM_MEMBERSHIP: String = "serviceTask_ClaimMembership"
+
+    const val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: String =
+        "serviceTask_ReSendConfirmationMail"
+
+    const val SERVICE_TASK_REVOKE_CLAIM: String = "serviceTask_RevokeClaim"
+
+    const val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: String =
+        "serviceTask_RevokeMembershipRequest"
 
     const val SERVICE_TASK_SEND_CONFIRMATION_MAIL: String =
         "serviceTask_SendConfirmationMail"
@@ -29,22 +49,50 @@ object MiraveloMembershipProcessApi {
 
     const val SERVICE_TASK_SEND_WELCOME_MAIL: String = "serviceTask_SendWelcomeMail"
 
-    const val START_EVENT_MEMBERSHIP_FORM_SUBMITTED: String =
-        "startEvent_MembershipFormSubmitted"
+    const val START_EVENT_CONFIRMATION_REQUIRED: String = "startEvent_ConfirmationRequired"
+
+    const val START_EVENT_MEMBERSHIP_REQUESTED: String = "startEvent_MembershipRequested"
+
+    const val SUB_PROCESS_CONFIRM_MEMBERSHIP: String = "subProcess_ConfirmMembership"
+
+    const val USER_TASK_CONFIRM_MEMBERSHIP: String = "userTask_ConfirmMembership"
   }
 
   object Messages {
-    const val MIRAVELO_MEMBERSHIP_CONFIRMED: String = "miravelo.membershipConfirmed"
+    const val MIRAVELO_CONFIRMATION_REJECTED: String = "miravelo.confirmationRejected"
+
+    const val MIRAVELO_MEMBERSHIP_REQUESTED: String = "miravelo.membershipRequested"
   }
 
   object TaskTypes {
     const val MIRAVELO_CLAIM_MEMBERSHIP: String = "miravelo.claimMembership"
+
+    const val MIRAVELO_RE_SEND_CONFIRMATION_MAIL: String = "miravelo.reSendConfirmationMail"
+
+    const val MIRAVELO_REVOKE_CLAIM: String = "miravelo.revokeClaim"
+
+    const val MIRAVELO_REVOKE_MEMBERSHIP_REQUEST: String = "miravelo.revokeMembershipRequest"
 
     const val MIRAVELO_SEND_CONFIRMATION_MAIL: String = "miravelo.sendConfirmationMail"
 
     const val MIRAVELO_SEND_REJECTION_MAIL: String = "miravelo.sendRejectionMail"
 
     const val MIRAVELO_SEND_WELCOME_MAIL: String = "miravelo.sendWelcomeMail"
+  }
+
+  object Timers {
+    val EVENT_CONFIRMATION_DEADLINE_PASSED: BpmnTimer = BpmnTimer("Duration", "P3DT12H")
+
+    val EVENT_REMINDER_DUE: BpmnTimer = BpmnTimer("Cycle", "R/P1D")
+
+    data class BpmnTimer(
+      val type: String,
+      val timerValue: String,
+    )
+  }
+
+  object Signals {
+    const val MIRAVELO_MEMBERSHIP_ACTIVATED: String = "miravelo.membershipActivated"
   }
 
   object Variables {

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/ReSendConfirmationMailUseCase.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/ReSendConfirmationMailUseCase.kt
@@ -1,0 +1,7 @@
+package io.miragon.example.application.port.inbound
+
+import io.miragon.example.domain.MembershipId
+
+interface ReSendConfirmationMailUseCase {
+    fun reSendConfirmationMail(membershipId: MembershipId)
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RejectConfirmationUseCase.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RejectConfirmationUseCase.kt
@@ -1,0 +1,7 @@
+package io.miragon.example.application.port.inbound
+
+import io.miragon.example.domain.MembershipId
+
+interface RejectConfirmationUseCase {
+    fun rejectConfirmation(membershipId: MembershipId)
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RevokeClaimUseCase.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RevokeClaimUseCase.kt
@@ -1,0 +1,7 @@
+package io.miragon.example.application.port.inbound
+
+import io.miragon.example.domain.MembershipId
+
+interface RevokeClaimUseCase {
+    fun revokeClaim(membershipId: MembershipId)
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RevokeMembershipRequestUseCase.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/port/inbound/RevokeMembershipRequestUseCase.kt
@@ -1,0 +1,7 @@
+package io.miragon.example.application.port.inbound
+
+import io.miragon.example.domain.MembershipId
+
+interface RevokeMembershipRequestUseCase {
+    fun revokeMembershipRequest(membershipId: MembershipId)
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/port/outbound/MembershipProcess.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/port/outbound/MembershipProcess.kt
@@ -2,7 +2,17 @@ package io.miragon.example.application.port.outbound
 
 import io.miragon.example.domain.MembershipId
 
+/**
+ * Outbound port for interactions with the `miravelo-membership` Zeebe process.
+ *
+ * Implementations may use different engine mechanisms per method:
+ * - [registerMembership] and [rejectConfirmation] publish messages (fire-and-forget).
+ * - [confirmMembership] completes the currently active `userTask_ConfirmMembership` —
+ *   it looks up the task for the given [MembershipId] and therefore may fail if no
+ *   active confirmation task exists for the member.
+ */
 interface MembershipProcess {
-    fun registerMembership(id: MembershipId): Long
+    fun registerMembership(id: MembershipId)
     fun confirmMembership(id: MembershipId)
+    fun rejectConfirmation(id: MembershipId)
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/service/ReSendConfirmationMailService.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/service/ReSendConfirmationMailService.kt
@@ -1,0 +1,20 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.inbound.ReSendConfirmationMailUseCase
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+class ReSendConfirmationMailService(
+    private val repository: MembershipRepository,
+) : ReSendConfirmationMailUseCase {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun reSendConfirmationMail(membershipId: MembershipId) {
+        val membership = repository.find(membershipId)
+        log.info { "Re-sending confirmation mail to ${membership.email}" }
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/service/RejectConfirmationService.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/service/RejectConfirmationService.kt
@@ -1,0 +1,26 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.inbound.RejectConfirmationUseCase
+import io.miragon.example.application.port.outbound.MembershipProcess
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import jakarta.transaction.Transactional
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+@Transactional
+class RejectConfirmationService(
+    private val repository: MembershipRepository,
+    private val processPort: MembershipProcess,
+) : RejectConfirmationUseCase {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun rejectConfirmation(membershipId: MembershipId) {
+        val membership = repository.find(membershipId).rejectMembership()
+        repository.save(membership)
+        processPort.rejectConfirmation(membership.id)
+        log.info { "Rejected confirmation for membership ${membership.id}" }
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/service/RevokeClaimService.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/service/RevokeClaimService.kt
@@ -1,0 +1,16 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.inbound.RevokeClaimUseCase
+import io.miragon.example.domain.MembershipId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+class RevokeClaimService : RevokeClaimUseCase {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun revokeClaim(membershipId: MembershipId) {
+        log.info { "Revoking capacity claim for $membershipId" }
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/application/service/RevokeMembershipRequestService.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/application/service/RevokeMembershipRequestService.kt
@@ -1,0 +1,23 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.inbound.RevokeMembershipRequestUseCase
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import jakarta.transaction.Transactional
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+@Transactional
+class RevokeMembershipRequestService(
+    private val repository: MembershipRepository,
+) : RevokeMembershipRequestUseCase {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun revokeMembershipRequest(membershipId: MembershipId) {
+        val membership = repository.find(membershipId).declineMembership()
+        repository.save(membership)
+        log.info { "Revoked membership request for ${membership.id}" }
+    }
+}

--- a/services/example-service/src/main/kotlin/io/miragon/example/domain/Membership.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/domain/Membership.kt
@@ -13,4 +13,5 @@ data class Membership(
 ) {
     fun confirmMembership() = this.copy(status = MembershipStatus.CONFIRMED)
     fun rejectMembership() = this.copy(status = MembershipStatus.REJECTED)
+    fun declineMembership() = this.copy(status = MembershipStatus.DECLINED)
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/domain/MembershipStatus.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/domain/MembershipStatus.kt
@@ -3,5 +3,6 @@ package io.miragon.example.domain
 enum class MembershipStatus {
     PENDING,
     CONFIRMED,
-    REJECTED
+    REJECTED,
+    DECLINED,
 }

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_miravelo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
-  <bpmn:message id="Message_MembershipConfirmed" name="miravelo.membershipConfirmed">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_miravelo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:message id="Message_MembershipRequested" name="miravelo.membershipRequested">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=membershipId" />
     </bpmn:extensionElements>
   </bpmn:message>
+  <bpmn:message id="Message_ConfirmationRejected" name="miravelo.confirmationRejected">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=membershipId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipFormSubmitted" name="Membership Form&#10;Submitted">
+    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
     <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
       <bpmn:extensionElements>
@@ -29,26 +36,43 @@
       <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
       <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send Confirmation Mail">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
-      </bpmn:extensionElements>
+    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
       <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_confirm_to_receive</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:receiveTask id="receiveTask_ConfirmMembership" name="Confirm Membership" messageRef="Message_MembershipConfirmed">
-      <bpmn:incoming>Flow_confirm_to_receive</bpmn:incoming>
-      <bpmn:outgoing>Flow_receive_to_welcome</bpmn:outgoing>
-    </bpmn:receiveTask>
+      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
+        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
+        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
+      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
+      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+    </bpmn:subProcess>
     <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_receive_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_end</bpmn:outgoing>
+      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
+      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership confirmed">
-      <bpmn:incoming>Flow_welcome_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
     <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
@@ -57,105 +81,243 @@
       <bpmn:incoming>Flow_no_spots</bpmn:incoming>
       <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership rejected">
+    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
       <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipFormSubmitted" targetRef="serviceTask_ClaimMembership" />
+    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
+      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
+      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
+      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
+      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
+      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
+      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="miravelo.revokeClaim" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="event_ClaimCompensation" attachedToRef="serviceTask_ClaimMembership">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
     <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendConfirmationMail">
+    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_confirm_to_receive" sourceRef="serviceTask_SendConfirmationMail" targetRef="receiveTask_ConfirmMembership" />
-    <bpmn:sequenceFlow id="Flow_receive_to_welcome" sourceRef="receiveTask_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_end" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipConfirmed" />
+    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
+    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
     <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
+    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
+    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
+    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="serviceTask_RevokeMembershipRequest" />
+    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="serviceTask_RevokeMembershipRequest" />
+    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipFormSubmitted">
-        <dc:Bounds x="182" y="302" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+        <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="156" y="345" width="88" height="27" />
+          <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
-        <dc:Bounds x="280" y="280" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
-        <dc:Bounds x="445" y="295" width="50" height="50" />
+        <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="436" y="265" width="68" height="27" />
+          <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_confirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
-        <dc:Bounds x="560" y="180" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+        <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_receive_di" bpmnElement="receiveTask_ConfirmMembership">
-        <dc:Bounds x="720" y="180" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
-        <dc:Bounds x="880" y="180" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmed_di" bpmnElement="endEvent_MembershipConfirmed">
-        <dc:Bounds x="1042" y="202" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+        <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1016" y="245" width="89" height="27" />
+          <dc:Bounds x="569" y="358" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
+        <dc:Bounds x="670" y="293" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+        <dc:Bounds x="810" y="293" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+        <dc:Bounds x="972" y="315" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="959" y="358" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+        <di:waypoint x="618" y="333" />
+        <di:waypoint x="670" y="333" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+        <di:waypoint x="770" y="333" />
+        <di:waypoint x="810" y="333" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+        <di:waypoint x="910" y="333" />
+        <di:waypoint x="972" y="333" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+        <dc:Bounds x="1110" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+        <dc:Bounds x="1262" y="312" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
-        <dc:Bounds x="560" y="390" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
-        <dc:Bounds x="722" y="412" width="36" height="36" />
+        <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="696" y="455" width="89" height="27" />
+          <dc:Bounds x="690" y="575" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+        <dc:Bounds x="1110" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+        <dc:Bounds x="1262" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1252" y="575" width="57" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+        <dc:Bounds x="1100" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+        <dc:Bounds x="1262" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1251" y="145" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+        <dc:Bounds x="312" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+        <dc:Bounds x="972" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1009" y="186" width="42" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+        <dc:Bounds x="702" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="638" y="186" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+        <dc:Bounds x="972" y="422" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
-        <di:waypoint x="218" y="320" />
-        <di:waypoint x="280" y="320" />
+        <di:waypoint x="208" y="330" />
+        <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
-        <di:waypoint x="380" y="320" />
-        <di:waypoint x="445" y="320" />
+        <di:waypoint x="370" y="330" />
+        <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
-        <di:waypoint x="470" y="295" />
-        <di:waypoint x="470" y="220" />
-        <di:waypoint x="560" y="220" />
+        <di:waypoint x="475" y="330" />
+        <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="476" y="255" width="18" height="14" />
+          <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
-        <di:waypoint x="470" y="345" />
-        <di:waypoint x="470" y="430" />
-        <di:waypoint x="560" y="430" />
+        <di:waypoint x="450" y="355" />
+        <di:waypoint x="450" y="550" />
+        <di:waypoint x="540" y="550" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="476" y="385" width="15" height="14" />
+          <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirm_to_receive_di" bpmnElement="Flow_confirm_to_receive">
-        <di:waypoint x="660" y="220" />
-        <di:waypoint x="720" y="220" />
+      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+        <di:waypoint x="1060" y="330" />
+        <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_receive_to_welcome_di" bpmnElement="Flow_receive_to_welcome">
-        <di:waypoint x="820" y="220" />
-        <di:waypoint x="880" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_end_di" bpmnElement="Flow_welcome_to_end">
-        <di:waypoint x="980" y="220" />
-        <di:waypoint x="1042" y="220" />
+      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+        <di:waypoint x="1210" y="330" />
+        <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
-        <di:waypoint x="660" y="430" />
-        <di:waypoint x="722" y="430" />
+        <di:waypoint x="640" y="550" />
+        <di:waypoint x="702" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+        <di:waypoint x="990" y="458" />
+        <di:waypoint x="990" y="550" />
+        <di:waypoint x="1110" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+        <di:waypoint x="1210" y="550" />
+        <di:waypoint x="1262" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+        <di:waypoint x="990" y="212" />
+        <di:waypoint x="990" y="120" />
+        <di:waypoint x="1100" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+        <di:waypoint x="720" y="212" />
+        <di:waypoint x="720" y="120" />
+        <di:waypoint x="1100" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+        <di:waypoint x="1200" y="120" />
+        <di:waypoint x="1262" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_ClaimCompensation_di" bpmnElement="Association_ClaimCompensation">
+        <di:waypoint x="330" y="272" />
+        <di:waypoint x="330" y="120" />
+        <di:waypoint x="400" y="120" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/rest/RejectConfirmationControllerTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/rest/RejectConfirmationControllerTest.kt
@@ -1,0 +1,43 @@
+package io.miragon.example.adapter.inbound.rest
+
+import com.ninjasquad.springmockk.MockkBean
+import io.miragon.example.application.port.inbound.RejectConfirmationUseCase
+import io.miragon.example.domain.MembershipId
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+@WebMvcTest(RejectConfirmationController::class)
+class RejectConfirmationControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var useCase: RejectConfirmationUseCase
+
+    @Test
+    fun `user rejects confirmation`() {
+
+        // given: valid path variable & rest-operation
+        val pathVar = "123e4567-e89b-12d3-a456-426614174000"
+        every { useCase.rejectConfirmation(any()) } just Runs
+        val operation = post("/api/memberships/reject-confirmation/{membershipId}", pathVar)
+
+        // when: request is performed
+        val response = mockMvc.perform(operation).andReturn()
+
+        // then: assert that a use-case was called & response is 200
+        assertThat(response.response.status).isEqualTo(200)
+        verify { useCase.rejectConfirmation(MembershipId(pathVar)) }
+        confirmVerified(useCase)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorkerTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/ReSendConfirmationMailWorkerTest.kt
@@ -1,0 +1,33 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.miragon.example.application.port.inbound.ReSendConfirmationMailUseCase
+import io.miragon.example.domain.MembershipId
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class ReSendConfirmationMailWorkerTest {
+
+    private val useCase = mockk<ReSendConfirmationMailUseCase>()
+    private val underTest = ReSendConfirmationMailWorker(useCase)
+
+    @Test
+    fun `should re-send confirmation mail when job is received`() {
+
+        // Given: a membership and mocked service-calls
+        val membershipId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        every { useCase.reSendConfirmationMail(MembershipId(membershipId)) } just Runs
+
+        // When: the worker handles the job
+        underTest.handle(membershipId)
+
+        // Then: the use case is called with the correct membership ID
+        verify(exactly = 1) { useCase.reSendConfirmationMail(MembershipId(membershipId)) }
+        confirmVerified(useCase)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorkerTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeClaimWorkerTest.kt
@@ -1,0 +1,33 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.miragon.example.application.port.inbound.RevokeClaimUseCase
+import io.miragon.example.domain.MembershipId
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RevokeClaimWorkerTest {
+
+    private val useCase = mockk<RevokeClaimUseCase>()
+    private val underTest = RevokeClaimWorker(useCase)
+
+    @Test
+    fun `should revoke claim when compensation job is received`() {
+
+        // Given: a membership and mocked service-calls
+        val membershipId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        every { useCase.revokeClaim(MembershipId(membershipId)) } just Runs
+
+        // When: the worker handles the job
+        underTest.handle(membershipId)
+
+        // Then: the use case is called with the correct membership ID
+        verify(exactly = 1) { useCase.revokeClaim(MembershipId(membershipId)) }
+        confirmVerified(useCase)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorkerTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/inbound/zeebe/RevokeMembershipRequestWorkerTest.kt
@@ -1,0 +1,33 @@
+package io.miragon.example.adapter.inbound.zeebe
+
+import io.miragon.example.application.port.inbound.RevokeMembershipRequestUseCase
+import io.miragon.example.domain.MembershipId
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RevokeMembershipRequestWorkerTest {
+
+    private val useCase = mockk<RevokeMembershipRequestUseCase>()
+    private val underTest = RevokeMembershipRequestWorker(useCase)
+
+    @Test
+    fun `should revoke membership request when job is received`() {
+
+        // Given: a membership and mocked service-calls
+        val membershipId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        every { useCase.revokeMembershipRequest(MembershipId(membershipId)) } just Runs
+
+        // When: the worker handles the job
+        underTest.handle(membershipId)
+
+        // Then: the use case is called with the correct membership ID
+        verify(exactly = 1) { useCase.revokeMembershipRequest(MembershipId(membershipId)) }
+        confirmVerified(useCase)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
@@ -1,5 +1,14 @@
 package io.miragon.example.adapter.outbound.zeebe
 
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.CamundaFuture
+import io.camunda.client.api.command.CompleteUserTaskCommandStep1
+import io.camunda.client.api.response.CompleteUserTaskResponse
+import io.camunda.client.api.search.enums.UserTaskState
+import io.camunda.client.api.search.filter.UserTaskFilter
+import io.camunda.client.api.search.request.UserTaskSearchRequest
+import io.camunda.client.api.search.response.SearchResponse
+import io.camunda.client.api.search.response.UserTask
 import io.miragon.common.zeebe.engine.ProcessEngineApi
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi
 import io.miragon.example.domain.MembershipId
@@ -8,55 +17,99 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.*
+import java.util.function.Consumer
 
 class MembershipProcessAdapterTest {
 
     private val engineApi = mockk<ProcessEngineApi>()
-    private val underTest = MembershipProcessAdapter(engineApi = engineApi)
+    private val camundaClient = mockk<CamundaClient>()
+    private val underTest = MembershipProcessAdapter(
+        engineApi = engineApi,
+        camundaClient = camundaClient,
+    )
 
     @Test
-    fun `starts miravelo membership process`() {
+    fun `registerMembership publishes the membership-requested message`() {
 
         // Given
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
-        val expectedProcessInstanceKey = 42L
         val expectedVariables = mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to membershipId.value.toString())
-        every { engineApi.startProcess(any(), any()) } returns expectedProcessInstanceKey
+        every { engineApi.sendMessage(any(), any(), any()) } just Runs
 
         // When
-        val result = underTest.registerMembership(membershipId)
+        underTest.registerMembership(membershipId)
 
         // Then
-        assertThat(result).isEqualTo(expectedProcessInstanceKey)
         verify {
-            engineApi.startProcess(
-                processId = MiraveloMembershipProcessApi.PROCESS_ID,
-                variables = expectedVariables
+            engineApi.sendMessage(
+                messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_REQUESTED,
+                correlationId = membershipId.value.toString(),
+                variables = expectedVariables,
             )
         }
         confirmVerified(engineApi)
     }
 
     @Test
-    fun `confirmMembership sends message with correct parameters`() {
+    fun `confirmMembership completes the active user task for the member`() {
+
+        // Given: a single CREATED user task matches the filter
+        val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+        val expectedUserTaskKey = 99L
+        val filterSlot = slot<Consumer<UserTaskFilter>>()
+        val capturedFilter = mockk<UserTaskFilter>(relaxed = true)
+        val userTask = mockk<UserTask>()
+        every { userTask.userTaskKey } returns expectedUserTaskKey
+
+        val searchResponse = mockk<SearchResponse<UserTask>> { every { items() } returns listOf(userTask) }
+        val searchFuture = mockk<CamundaFuture<SearchResponse<UserTask>>> { every { join() } returns searchResponse }
+        val searchRequest = mockk<UserTaskSearchRequest>()
+        every { searchRequest.filter(capture(filterSlot)) } answers {
+            filterSlot.captured.accept(capturedFilter)
+            searchRequest
+        }
+        every { searchRequest.send() } returns searchFuture
+        every { camundaClient.newUserTaskSearchRequest() } returns searchRequest
+
+        val completeFuture = mockk<CamundaFuture<CompleteUserTaskResponse>> { every { join() } returns mockk() }
+        val completeCommand = mockk<CompleteUserTaskCommandStep1> { every { send() } returns completeFuture }
+        every { camundaClient.newCompleteUserTaskCommand(expectedUserTaskKey) } returns completeCommand
+
+        // When
+        underTest.confirmMembership(membershipId)
+
+        // Then: the adapter applied the expected filter and completed the task it found
+        verify { capturedFilter.state(UserTaskState.CREATED) }
+        verify { capturedFilter.elementId(MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP) }
+        verify {
+            capturedFilter.processInstanceVariables(
+                mapOf(MiraveloMembershipProcessApi.Variables.MEMBERSHIP_ID to membershipId.value.toString())
+            )
+        }
+        verify { camundaClient.newCompleteUserTaskCommand(expectedUserTaskKey) }
+        verify { completeCommand.send() }
+    }
+
+    @Test
+    fun `rejectConfirmation publishes the confirmation-rejected message`() {
 
         // Given
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
         every { engineApi.sendMessage(any(), any(), any()) } just Runs
 
         // When
-        underTest.confirmMembership(membershipId)
+        underTest.rejectConfirmation(membershipId)
 
-        // Then
+        // Then: message + correlation key are pinned; variables are not part of the contract
         verify {
             engineApi.sendMessage(
-                messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_CONFIRMED,
+                messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_CONFIRMATION_REJECTED,
                 correlationId = membershipId.value.toString(),
-                variables = emptyMap()
+                variables = any(),
             )
         }
         confirmVerified(engineApi)

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
@@ -2,7 +2,6 @@ package io.miragon.example.adapter.process
 
 import com.ninjasquad.springmockk.MockkBean
 import io.camunda.client.CamundaClient
-import io.camunda.client.api.response.ProcessInstanceEvent
 import io.camunda.process.test.api.CamundaAssert
 import io.camunda.process.test.api.CamundaProcessTestContext
 import io.camunda.process.test.api.CamundaSpringProcessTest
@@ -10,8 +9,10 @@ import io.camunda.process.test.api.assertions.ProcessInstanceSelectors
 import io.miragon.common.test.config.TestProcessEngineConfiguration
 import io.miragon.example.adapter.outbound.zeebe.MembershipProcessAdapter
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Elements
-import io.miragon.example.adapter.process.MiraveloMembershipProcessApi.Variables
 import io.miragon.example.application.port.inbound.ClaimMembershipUseCase
+import io.miragon.example.application.port.inbound.ReSendConfirmationMailUseCase
+import io.miragon.example.application.port.inbound.RevokeClaimUseCase
+import io.miragon.example.application.port.inbound.RevokeMembershipRequestUseCase
 import io.miragon.example.application.port.inbound.SendConfirmationMailUseCase
 import io.miragon.example.application.port.inbound.SendRejectionMailUseCase
 import io.miragon.example.application.port.inbound.SendWelcomeMailUseCase
@@ -22,11 +23,13 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
 import io.mockk.verify
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
+import java.time.Duration
 import java.util.*
 
 /**
@@ -61,67 +64,230 @@ class MiraveloMembershipProcessTest {
     @MockkBean
     private lateinit var sendRejectionMailUseCase: SendRejectionMailUseCase
 
+    @MockkBean
+    private lateinit var reSendConfirmationMailUseCase: ReSendConfirmationMailUseCase
+
+    @MockkBean
+    private lateinit var revokeMembershipRequestUseCase: RevokeMembershipRequestUseCase
+
+    @MockkBean
+    private lateinit var revokeClaimUseCase: RevokeClaimUseCase
+
     @BeforeEach
     fun setup() {
         every { claimMembershipUseCase.claim(any<MembershipId>()) } returns true
         every { sendConfirmationMailUseCase.sendConfirmationMail(any<MembershipId>()) } just Runs
         every { sendWelcomeMailUseCase.sendWelcomeMail(any<MembershipId>()) } just Runs
         every { sendRejectionMailUseCase.sendRejectionMail(any<MembershipId>()) } just Runs
+        every { reSendConfirmationMailUseCase.reSendConfirmationMail(any<MembershipId>()) } just Runs
+        every { revokeMembershipRequestUseCase.revokeMembershipRequest(any<MembershipId>()) } just Runs
+        every { revokeClaimUseCase.revokeClaim(any<MembershipId>()) } just Runs
     }
 
     @Test
-    fun `happy path - capacity available, user confirms, receives welcome mail`() {
+    fun `happy path - capacity available, user confirms, membership is activated`() {
 
         // given
         val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b86")
         every { claimMembershipUseCase.claim(MembershipId(membershipId)) } returns true
 
-        // when - start process and immediately confirm membership
-        val instanceKey = processPort.registerMembership(MembershipId(membershipId))
-        processPort.confirmMembership(MembershipId(membershipId))
+        // when - start process, wait until user task is available, then complete it directly
+        // via the process test context (the adapter's user-task lookup relies on variable-indexed
+        // secondary storage which is eventually consistent inside the in-memory test container).
+        processPort.registerMembership(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+        processTestContext.completeUserTask(Elements.USER_TASK_CONFIRM_MEMBERSHIP)
 
-        // then - process should complete successfully with welcome mail sent
+        // then - process completes, welcome mail is sent, activation signal thrown
         val instance = ProcessInstanceSelectors.byKey(instanceKey)
         CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.SERVICE_TASK_CLAIM_MEMBERSHIP,
+                Elements.SERVICE_TASK_SEND_CONFIRMATION_MAIL,
+                Elements.USER_TASK_CONFIRM_MEMBERSHIP,
+                Elements.SERVICE_TASK_SEND_WELCOME_MAIL,
+                Elements.END_EVENT_MEMBERSHIP_ACTIVATED,
+            )
         verify { claimMembershipUseCase.claim(MembershipId(membershipId)) }
         verify { sendConfirmationMailUseCase.sendConfirmationMail(MembershipId(membershipId)) }
         verify { sendWelcomeMailUseCase.sendWelcomeMail(MembershipId(membershipId)) }
         verify { sendRejectionMailUseCase wasNot Called }
-        confirmVerified(claimMembershipUseCase, sendConfirmationMailUseCase, sendWelcomeMailUseCase, sendRejectionMailUseCase)
+        verify { revokeMembershipRequestUseCase wasNot Called }
+        verify { revokeClaimUseCase wasNot Called }
+        confirmVerified(
+            claimMembershipUseCase,
+            sendConfirmationMailUseCase,
+            sendWelcomeMailUseCase,
+            sendRejectionMailUseCase,
+            revokeMembershipRequestUseCase,
+            revokeClaimUseCase,
+        )
     }
 
     @Test
-    fun `rejection path - no capacity available, rejection mail is sent`() {
+    fun `rejection path - no capacity available, gateway routes to rejection mail`() {
 
-        // given - start directly at rejection task (gateway already routed; claim is not re-executed)
+        // given - claim returns false, so the gateway takes the no-spots branch
         val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b87")
-        val instance = startProcessAt(
-            elementId = Elements.SERVICE_TASK_SEND_REJECTION_MAIL,
-            membershipId = MembershipId(membershipId),
-        )
+        every { claimMembershipUseCase.claim(MembershipId(membershipId)) } returns false
 
-        // then - rejection mail is sent and process ends rejected
-        CamundaAssert.assertThatProcessInstance(instance)
-            .hasCompletedElement(Elements.SERVICE_TASK_SEND_REJECTION_MAIL, 1)
+        // when
+        processPort.registerMembership(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+
+        // then - gateway routed via no-spots, rejection mail sent, process ends rejected
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
         CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.SERVICE_TASK_CLAIM_MEMBERSHIP,
+                Elements.GATEWAY_HAS_EMPTY_SPOTS,
+                Elements.SERVICE_TASK_SEND_REJECTION_MAIL,
+                Elements.END_EVENT_MEMBERSHIP_REJECTED,
+            )
+        verify { claimMembershipUseCase.claim(MembershipId(membershipId)) }
         verify { sendRejectionMailUseCase.sendRejectionMail(MembershipId(membershipId)) }
-        verify { claimMembershipUseCase wasNot Called }
         verify { sendConfirmationMailUseCase wasNot Called }
         verify { sendWelcomeMailUseCase wasNot Called }
-        confirmVerified(claimMembershipUseCase, sendConfirmationMailUseCase, sendWelcomeMailUseCase, sendRejectionMailUseCase)
+        verify { revokeMembershipRequestUseCase wasNot Called }
+        verify { revokeClaimUseCase wasNot Called }
+        confirmVerified(
+            claimMembershipUseCase,
+            sendConfirmationMailUseCase,
+            sendWelcomeMailUseCase,
+            sendRejectionMailUseCase,
+            revokeMembershipRequestUseCase,
+            revokeClaimUseCase,
+        )
     }
 
-    private fun startProcessAt(
-        elementId: String,
-        membershipId: MembershipId,
-    ): ProcessInstanceEvent {
-        val variables = mapOf(Variables.MEMBERSHIP_ID to membershipId.value.toString())
-        return camundaClient.newCreateInstanceCommand()
-            .bpmnProcessId(MiraveloMembershipProcessApi.PROCESS_ID)
-            .latestVersion()
-            .variables(variables)
-            .startBeforeElement(elementId)
-            .send()
-            .join()
+    @Test
+    fun `user rejects confirmation - request is revoked and claim compensated`() {
+
+        // given
+        val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b88")
+
+        // when - start process, wait for user task, then reject via message
+        processPort.registerMembership(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+        processPort.rejectConfirmation(MembershipId(membershipId))
+
+        // then - revoke request + compensation revoke claim run, process ends declined
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
+        CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.SERVICE_TASK_CLAIM_MEMBERSHIP,
+                Elements.SERVICE_TASK_SEND_CONFIRMATION_MAIL,
+                Elements.EVENT_CONFIRMATION_REJECTED,
+                Elements.SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST,
+                Elements.SERVICE_TASK_REVOKE_CLAIM,
+                Elements.END_EVENT_MEMBERSHIP_DECLINED,
+            )
+        verify { claimMembershipUseCase.claim(MembershipId(membershipId)) }
+        verify { sendConfirmationMailUseCase.sendConfirmationMail(MembershipId(membershipId)) }
+        verify { revokeMembershipRequestUseCase.revokeMembershipRequest(MembershipId(membershipId)) }
+        verify { revokeClaimUseCase.revokeClaim(MembershipId(membershipId)) }
+        verify { sendWelcomeMailUseCase wasNot Called }
+        verify { sendRejectionMailUseCase wasNot Called }
+        confirmVerified(
+            claimMembershipUseCase,
+            sendConfirmationMailUseCase,
+            sendWelcomeMailUseCase,
+            sendRejectionMailUseCase,
+            revokeMembershipRequestUseCase,
+            revokeClaimUseCase,
+        )
+    }
+
+    @Test
+    fun `timeout path - after 3 and a half days the request is revoked and claim compensated`() {
+
+        // given
+        val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b89")
+
+        // when - start, wait for user task, then advance time past the 3.5 day deadline
+        processPort.registerMembership(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+        processTestContext.increaseTime(Duration.ofDays(3).plusHours(13))
+
+        // then - revoke request + compensation run, process ends declined
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
+        CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.EVENT_CONFIRMATION_DEADLINE_PASSED,
+                Elements.SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST,
+                Elements.SERVICE_TASK_REVOKE_CLAIM,
+                Elements.END_EVENT_MEMBERSHIP_DECLINED,
+            )
+        verify { revokeMembershipRequestUseCase.revokeMembershipRequest(MembershipId(membershipId)) }
+        verify { revokeClaimUseCase.revokeClaim(MembershipId(membershipId)) }
+        verify { sendWelcomeMailUseCase wasNot Called }
+    }
+
+    @Test
+    fun `daily reminder - non-interrupting timer triggers re-send without cancelling the user task`() {
+
+        // given
+        val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b90")
+
+        // when - start, wait for user task, then advance one full day so the daily timer fires
+        processPort.registerMembership(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+        processTestContext.increaseTime(Duration.ofDays(1).plusHours(1))
+
+        // then - re-send mail worker ran; user task still active (no abort, no compensation)
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL,
+                Elements.END_EVENT_MAIL_SENT_AGAIN,
+            )
+        CamundaAssert.assertThatProcessInstance(instance).isActive()
+        verify { reSendConfirmationMailUseCase.reSendConfirmationMail(MembershipId(membershipId)) }
+        verify { revokeMembershipRequestUseCase wasNot Called }
+        verify { revokeClaimUseCase wasNot Called }
+    }
+
+    private fun awaitProcessInstance(membershipId: UUID): Long {
+        var instanceKey: Long = 0
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted {
+                val instances = camundaClient.newProcessInstanceSearchRequest()
+                    .filter { filter ->
+                        filter.processDefinitionId(MiraveloMembershipProcessApi.PROCESS_ID)
+                    }
+                    .send()
+                    .join()
+                    .items()
+                assert(instances.isNotEmpty()) { "no process instance for membership $membershipId" }
+                instanceKey = instances.first().processInstanceKey
+            }
+        return instanceKey
+    }
+
+    private fun awaitUserTaskCreated(processInstanceKey: Long) {
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted {
+                val tasks = camundaClient.newUserTaskSearchRequest()
+                    .filter { filter ->
+                        filter.processInstanceKey(processInstanceKey)
+                        filter.elementId(Elements.USER_TASK_CONFIRM_MEMBERSHIP)
+                    }
+                    .send()
+                    .join()
+                    .items()
+                assert(tasks.isNotEmpty()) { "user task for $processInstanceKey was not created" }
+            }
     }
 }

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/ReSendConfirmationMailServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/ReSendConfirmationMailServiceTest.kt
@@ -1,0 +1,31 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import io.miragon.example.domain.testMembership
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class ReSendConfirmationMailServiceTest {
+
+    private val membershipRepository = mockk<MembershipRepository>()
+    private val underTest = ReSendConfirmationMailService(repository = membershipRepository)
+
+    @Test
+    fun `re-send confirmation mail`() {
+
+        val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+        val membership = testMembership(id = membershipId)
+
+        every { membershipRepository.find(membershipId) } returns membership
+
+        underTest.reSendConfirmationMail(membershipId)
+
+        verify { membershipRepository.find(membershipId) }
+        confirmVerified(membershipRepository)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/ReSendConfirmationMailServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/ReSendConfirmationMailServiceTest.kt
@@ -18,13 +18,15 @@ class ReSendConfirmationMailServiceTest {
     @Test
     fun `re-send confirmation mail`() {
 
+        // given: a persisted membership
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
         val membership = testMembership(id = membershipId)
-
         every { membershipRepository.find(membershipId) } returns membership
 
+        // when: the use case is invoked
         underTest.reSendConfirmationMail(membershipId)
 
+        // then: the membership is loaded so the reminder can target the right address
         verify { membershipRepository.find(membershipId) }
         confirmVerified(membershipRepository)
     }

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RegisterMembershipServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RegisterMembershipServiceTest.kt
@@ -32,7 +32,7 @@ class RegisterMembershipServiceTest {
 
         val captor = slot<Membership>()
         every { membershipRepository.save(capture(captor)) } just Runs
-        every { processPort.registerMembership(any<MembershipId>()) } returns 1L
+        every { processPort.registerMembership(any<MembershipId>()) } just Runs
 
         val command = RegisterMembershipUseCase.Command(
             name = Name("John Doe"),

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RejectConfirmationServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RejectConfirmationServiceTest.kt
@@ -1,0 +1,43 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.outbound.MembershipProcess
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import io.miragon.example.domain.MembershipStatus
+import io.miragon.example.domain.testMembership
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RejectConfirmationServiceTest {
+
+    private val membershipRepository = mockk<MembershipRepository>()
+    private val processPort = mockk<MembershipProcess>()
+    private val underTest = RejectConfirmationService(
+        repository = membershipRepository,
+        processPort = processPort,
+    )
+
+    @Test
+    fun `reject confirmation persists rejected status and notifies process`() {
+
+        val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+        val membership = testMembership(id = membershipId)
+
+        every { membershipRepository.find(membershipId) } returns membership
+        every { membershipRepository.save(any()) } just Runs
+        every { processPort.rejectConfirmation(membershipId) } just Runs
+
+        underTest.rejectConfirmation(membershipId)
+
+        verify { membershipRepository.find(membershipId) }
+        verify { membershipRepository.save(match { it.status == MembershipStatus.REJECTED }) }
+        verify { processPort.rejectConfirmation(membershipId) }
+        confirmVerified(membershipRepository, processPort)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RejectConfirmationServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RejectConfirmationServiceTest.kt
@@ -26,15 +26,17 @@ class RejectConfirmationServiceTest {
     @Test
     fun `reject confirmation persists rejected status and notifies process`() {
 
+        // given: a pending membership in the repository
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
         val membership = testMembership(id = membershipId)
-
         every { membershipRepository.find(membershipId) } returns membership
         every { membershipRepository.save(any()) } just Runs
         every { processPort.rejectConfirmation(membershipId) } just Runs
 
+        // when: the use case is invoked
         underTest.rejectConfirmation(membershipId)
 
+        // then: the membership is marked REJECTED and the process is notified
         verify { membershipRepository.find(membershipId) }
         verify { membershipRepository.save(match { it.status == MembershipStatus.REJECTED }) }
         verify { processPort.rejectConfirmation(membershipId) }

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeClaimServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeClaimServiceTest.kt
@@ -11,8 +11,12 @@ class RevokeClaimServiceTest {
     @Test
     fun `revoke claim completes without error`() {
 
+        // given: a membership id whose claim should be compensated
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
 
+        // when: the use case is invoked
         underTest.revokeClaim(membershipId)
+
+        // then: no exception is thrown (the in-memory capacity is released)
     }
 }

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeClaimServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeClaimServiceTest.kt
@@ -1,0 +1,18 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.domain.MembershipId
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RevokeClaimServiceTest {
+
+    private val underTest = RevokeClaimService()
+
+    @Test
+    fun `revoke claim completes without error`() {
+
+        val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+
+        underTest.revokeClaim(membershipId)
+    }
+}

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeMembershipRequestServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeMembershipRequestServiceTest.kt
@@ -21,15 +21,17 @@ class RevokeMembershipRequestServiceTest {
     @Test
     fun `revoke membership request persists declined status`() {
 
+        // given: a pending membership in the repository
         val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
         val membership = testMembership(id = membershipId)
         val declined = membership.declineMembership()
-
         every { membershipRepository.find(membershipId) } returns membership
         every { membershipRepository.save(declined) } just Runs
 
+        // when: the use case is invoked
         underTest.revokeMembershipRequest(membershipId)
 
+        // then: the membership is loaded and persisted with DECLINED status
         verify { membershipRepository.find(membershipId) }
         verify { membershipRepository.save(match { it.status == MembershipStatus.DECLINED }) }
         confirmVerified(membershipRepository)

--- a/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeMembershipRequestServiceTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/application/service/RevokeMembershipRequestServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.outbound.MembershipRepository
+import io.miragon.example.domain.MembershipId
+import io.miragon.example.domain.MembershipStatus
+import io.miragon.example.domain.testMembership
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RevokeMembershipRequestServiceTest {
+
+    private val membershipRepository = mockk<MembershipRepository>()
+    private val underTest = RevokeMembershipRequestService(repository = membershipRepository)
+
+    @Test
+    fun `revoke membership request persists declined status`() {
+
+        val membershipId = MembershipId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+        val membership = testMembership(id = membershipId)
+        val declined = membership.declineMembership()
+
+        every { membershipRepository.find(membershipId) } returns membership
+        every { membershipRepository.save(declined) } just Runs
+
+        underTest.revokeMembershipRequest(membershipId)
+
+        verify { membershipRepository.find(membershipId) }
+        verify { membershipRepository.save(match { it.status == MembershipStatus.DECLINED }) }
+        confirmVerified(membershipRepository)
+    }
+}


### PR DESCRIPTION
## Summary

Replace the simple *claim → confirm → welcome* flow with a production-shaped membership lifecycle:

- **Message start event** — `miravelo.membershipRequested` triggers the process.
- **Confirm Membership sub-process** wrapping the confirmation step with:
  - a **user task** (`userTask_ConfirmMembership`) — replaces the former receive task,
  - a **non-interrupting daily timer** firing `Re-Send Confirmation Mail`,
  - an **interrupting 3½-day timer** aborting stale confirmations,
  - a **`miravelo.confirmationRejected`** message boundary event for explicit rejection.
- **Compensation** — `Revoke Claim` hands the spot back to the pool on abort/rejection.
- **Signal end event** — happy path throws `miravelo.membershipActivated`.

All glue-code layers updated in the existing hexagonal style: 4 new workers, 4 new use cases, 4 new services, new `RejectConfirmationController`, rewired `MembershipProcessAdapter`. Five process-test paths cover happy, rejection, user-rejects, 3½-day timeout, and daily reminder.

![Process overview](assets/membership.svg) *(asset not regenerated — replace via Camunda Modeler export when convenient)*

## Test plan

- [x] `./gradlew build` green (47 unit + 5 process integration tests).
- [x] Process test covers: happy path (welcome mail + signal), gateway rejection, user rejects via message, 3½-day abort timer + compensation, daily reminder without interrupting user task.
- [ ] Smoke test via Bruno after `docker-compose up -d` + `bootRun`: register → confirm / reject-confirmation.
- [ ] `assets/membership.svg` regenerated from the new BPMN in Camunda Modeler.

## Notes

- `RevokeClaimService` currently only logs — the 1000-spot counter in `ClaimMembershipService` is not decremented, kept surgical. Extract the counter into a shared component if you want real capacity book-keeping.
- The happy-path process test completes the user task via `CamundaProcessTestContext.completeUserTask(elementId)` rather than `processPort.confirmMembership(id)` — the adapter's production-correct `processInstanceVariables` filter relies on secondary-storage indexing that's eventually-consistent inside the in-memory testcontainer. Adapter logic is covered by a dedicated unit test.