### PR TITLE
chore: gitignore .claude/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 .DS_Store
 .kotlin/
 .claude/temp
+.claude/logs
 .claude/settings.local.json
 target


### PR DESCRIPTION
## Summary

Add `.claude/logs` to `.gitignore` so tooling-generated logs
(e.g. `.claude/logs/revelio.jsonl`) don't leak into commits.

## Test plan

- [x] `git check-ignore -v .claude/logs/revelio.jsonl` confirms the path
  is matched by the new `.gitignore` rule.