### PR TITLE
chore(deps): group docker-compose dependabot updates like other ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,14 @@ updates:
       - "dependencies"
     assignees:
       - "emaarco"
+    groups:
+      docker-compose:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+          - "major"
 
   # Config for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Follow-up to #71.

Adds a `docker-compose` group to the Dependabot config so the three stack images (`postgres`, `camunda/camunda`, `elasticsearch`) are bundled into a single grouped PR — matching the existing `gradle` (`backend-dependencies`) and `github-actions` groups (`patterns: "*"`, all update-types).