### PR TITLE
feat(zeebe): start a process at a specific element

### DIFF
--- a/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
+++ b/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
@@ -1,11 +1,14 @@
 package io.miragon.common.zeebe.engine
 
+import io.github.emaarco.bpmn.runtime.ElementId
 import io.github.emaarco.bpmn.runtime.MessageName
 import io.github.emaarco.bpmn.runtime.ProcessId
 import io.github.emaarco.bpmn.runtime.VariableName
 import io.miragon.common.zeebe.context.EventualConsistent
 import io.miragon.common.zeebe.context.StronglyConsistent
 import io.camunda.client.CamundaClient
+import io.camunda.client.api.search.enums.ElementInstanceState
+import io.camunda.client.api.search.enums.ElementInstanceType
 import io.camunda.client.api.search.response.ProcessInstance
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -32,6 +35,74 @@ open class ProcessEngineApi(
             .send()
             .join()
             .processInstanceKey
+    }
+
+    /**
+     * Starts a process instance via its definition directly BEFORE the given element
+     * (Camunda start instruction). Elements before the target are skipped.
+     *
+     * This happens in a single, atomic command. It is intended for local experimentation
+     * and tests - NOT for regular production use (see Camunda's "run a process segment").
+     *
+     * Note: variables that earlier (skipped) tasks would normally set must be provided
+     * here, otherwise gateways / IO-mappings after the target may raise incidents.
+     *
+     * @param processId the id of the process to start
+     * @param targetElement the element the instance should be started at (started "before" it)
+     * @param variables the variables that should be passed to the process
+     * @return the key of the process instance
+     */
+    @StronglyConsistent
+    open fun startProcessAtElementViaDefinition(
+        processId: ProcessId,
+        targetElement: ElementId,
+        variables: Map<VariableName, Any> = emptyMap(),
+    ): Long {
+        return camundaClient.newCreateInstanceCommand()
+            .bpmnProcessId(processId.value)
+            .latestVersion()
+            .startBeforeElement(targetElement.value)
+            .variables(variables.mapKeys { it.key.value })
+            .send()
+            .join()
+            .processInstanceKey
+    }
+
+    /**
+     * Starts a process instance via a message (at its message start event) and then moves
+     * the token to the given target element using process instance modification.
+     *
+     * ATTENTION: this is multi-step and NOT atomic. It is a pure test / intervention tool.
+     * After the message-start the instance keeps running, so it is moved from whatever leaf
+     * element it currently waits at - this is only deterministic if the process settles at a
+     * single stable wait state (the common case; we wait for that state before moving). The
+     * token is moved by element id (the engine resolves the live element instances), with the
+     * target's ancestor scope inferred - so we never reference stale element instance keys.
+     *
+     * @param messageName the message that triggers the message start event
+     * @param correlationId the correlation key for the message
+     * @param targetElement the element the token should be moved to
+     * @param variables the variables that should be passed to the process
+     * @return the key of the process instance
+     */
+    @StronglyConsistent
+    open fun startProcessAtElementViaMessage(
+        messageName: MessageName,
+        correlationId: String,
+        targetElement: ElementId,
+        variables: Map<VariableName, Any> = emptyMap(),
+    ): Long {
+        // 1) start the instance at the message start event; correlateMessage returns the instance key
+        val processInstanceKey = camundaClient.newCorrelateMessageCommand()
+            .messageName(messageName.value)
+            .correlationKey(correlationId)
+            .variables(variables.mapKeys { it.key.value })
+            .send()
+            .join()
+            .processInstanceKey
+        // 2) once the instance has settled at its wait state, move the token to the target
+        moveTokenToTarget(processInstanceKey, targetElement)
+        return processInstanceKey
     }
 
     /**
@@ -64,6 +135,72 @@ open class ProcessEngineApi(
     open fun searchForProcessInstances(): List<ProcessInstance> {
         val instances = camundaClient.newProcessInstanceSearchRequest().send().join()
         return instances.items()
+    }
+
+    /**
+     * Waits until the instance sits at a single active leaf element, then - unless it is already
+     * the target - moves the token there. The move is issued by element id (not instance key), so
+     * the engine resolves the live element instances itself; the call is retried because the
+     * element-instance search we read the current position from is eventually consistent.
+     */
+    private fun moveTokenToTarget(processInstanceKey: Long, targetElement: ElementId) {
+        var previous: String? = null
+        await(SEARCH_TIMEOUT) {
+            val source = singleActiveLeafElementId(processInstanceKey)
+            val stable = source != null && source == previous // only act on a settled wait state
+            previous = source
+            when {
+                source == null || !stable -> null // not settled yet (or a transient element) -> keep polling
+                source == targetElement.value -> DONE // already settled at the target
+                else -> runCatching {
+                    camundaClient.newModifyProcessInstanceCommand(processInstanceKey)
+                        .moveElementsWithInferredAncestor(source, targetElement.value)
+                        .send()
+                        .join()
+                    DONE
+                }.getOrNull() // null on rejection (token already moved on) -> keep retrying
+            }
+        }
+    }
+
+    /** The element id of the single active leaf (non-container) element, or null if not exactly one. */
+    private fun singleActiveLeafElementId(processInstanceKey: Long): String? =
+        camundaClient.newElementInstanceSearchRequest()
+            .filter { filter ->
+                filter.processInstanceKey(processInstanceKey)
+                filter.state(ElementInstanceState.ACTIVE)
+            }
+            .send()
+            .join()
+            .items()
+            .filter { it.type !in CONTAINER_ELEMENT_TYPES }
+            .singleOrNull()
+            ?.elementId
+
+    private fun <T : Any> await(timeout: Duration, action: () -> T?): T {
+        val deadline = System.currentTimeMillis() + timeout.toMillis()
+        while (System.currentTimeMillis() < deadline) {
+            action()?.let { return it }
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+        throw IllegalStateException("Timed out after $timeout while waiting for the process engine state")
+    }
+
+    private companion object {
+        private val SEARCH_TIMEOUT: Duration = Duration.ofSeconds(30)
+        private const val POLL_INTERVAL_MILLIS: Long = 200
+
+        /** Non-null sentinel so [await] can signal "done" from an action that has no result. */
+        private val DONE = Any()
+
+        /** Scope/container element types that hold no token themselves. */
+        private val CONTAINER_ELEMENT_TYPES = setOf(
+            ElementInstanceType.PROCESS,
+            ElementInstanceType.SUB_PROCESS,
+            ElementInstanceType.EVENT_SUB_PROCESS,
+            ElementInstanceType.AD_HOC_SUB_PROCESS,
+            ElementInstanceType.MULTI_INSTANCE_BODY,
+        )
     }
 
 }

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapter.kt
@@ -34,6 +34,35 @@ class MembershipProcessAdapter(
         )
     }
 
+    /**
+     * Demo: start the membership process directly at the confirmation user task via the
+     * process definition (atomic start instruction). Earlier steps (claim, confirmation mail)
+     * are skipped. For local experimentation / tests only.
+     */
+    fun startAtConfirmationViaDefinition(id: MembershipId): Long =
+        engineApi.startProcessAtElementViaDefinition(
+            processId = MiraveloMembershipProcessApi.PROCESS_ID,
+            targetElement = MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP,
+            variables = mapOf(
+                MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID to id.value.toString(),
+            ),
+        )
+
+    /**
+     * Demo: start the membership process via its message start event and then move the token
+     * to the confirmation user task (process instance modification). For local experimentation
+     * / tests only - multi-step and eventually consistent.
+     */
+    fun startAtConfirmationViaMessage(id: MembershipId): Long =
+        engineApi.startProcessAtElementViaMessage(
+            messageName = MiraveloMembershipProcessApi.Messages.MIRAVELO_MEMBERSHIP_REQUESTED,
+            correlationId = id.value.toString(),
+            targetElement = MiraveloMembershipProcessApi.Elements.USER_TASK_CONFIRM_MEMBERSHIP,
+            variables = mapOf(
+                MiraveloMembershipProcessApi.Variables.StartEventMembershipRequested.MEMBERSHIP_ID to id.value.toString(),
+            ),
+        )
+
     private fun findActiveConfirmUserTask(id: MembershipId): Long {
         return camundaClient.newUserTaskSearchRequest()
             .filter { filter ->

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessTest.kt
@@ -256,6 +256,58 @@ class MiraveloMembershipProcessTest {
         verify { revokeClaimUseCase wasNot Called }
     }
 
+    @Test
+    fun `start at confirmation via definition - skips earlier steps and waits at the user task`() {
+
+        // given
+        val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b91")
+
+        // when - start directly before the confirmation user task (claim + confirmation mail skipped)
+        processPort.startAtConfirmationViaDefinition(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+
+        // then - instance waits at the user task; earlier workers never ran
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
+        CamundaAssert.assertThatProcessInstance(instance).isActive()
+        verify { claimMembershipUseCase wasNot Called }
+        verify { sendConfirmationMailUseCase wasNot Called }
+
+        // and - completing the user task continues the happy path normally
+        processTestContext.completeUserTask(Elements.USER_TASK_CONFIRM_MEMBERSHIP.value)
+        CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        CamundaAssert.assertThatProcessInstance(instance)
+            .hasCompletedElements(
+                Elements.USER_TASK_CONFIRM_MEMBERSHIP,
+                Elements.SERVICE_TASK_SEND_WELCOME_MAIL,
+                Elements.END_EVENT_MEMBERSHIP_ACTIVATED,
+            )
+        verify { sendWelcomeMailUseCase.sendWelcomeMail(MembershipId(membershipId)) }
+    }
+
+    @Test
+    fun `start at confirmation via message - message start then token moved to the user task`() {
+
+        // given
+        val membershipId = UUID.fromString("4a607799-804b-43d1-8aa2-bdcc4dfd9b92")
+
+        // when - start via the message start event, then move the token to the user task
+        processPort.startAtConfirmationViaMessage(MembershipId(membershipId))
+        val instanceKey = awaitProcessInstance(membershipId)
+        awaitUserTaskCreated(instanceKey)
+
+        // then - unlike the definition variant, the real flow ran first (claim worker executed),
+        // and the instance now waits at the (re-activated) user task
+        val instance = ProcessInstanceSelectors.byKey(instanceKey)
+        CamundaAssert.assertThatProcessInstance(instance).isActive()
+        verify { claimMembershipUseCase.claim(MembershipId(membershipId)) }
+
+        // and - completing the user task continues the happy path normally
+        processTestContext.completeUserTask(Elements.USER_TASK_CONFIRM_MEMBERSHIP.value)
+        CamundaAssert.assertThatProcessInstance(instance).isCompleted()
+        verify { sendWelcomeMailUseCase.sendWelcomeMail(MembershipId(membershipId)) }
+    }
+
     private fun awaitProcessInstance(membershipId: UUID): Long {
         var instanceKey: Long = 0
         Awaitility.await()


### PR DESCRIPTION
## What & why

Adds the ability to start a process instance **at a specific element** in the model instead of at its start event — useful for local experimentation and tests (e.g. jumping straight to a confirmation user task without running the earlier steps).

Two new methods on `ProcessEngineApi` (existing `startProcess` / `sendMessage` left untouched):

### `startProcessAtElementViaDefinition(processId, targetElement, variables)`
Atomic, single command via `newCreateInstanceCommand().startBeforeElement(...)`. Elements before the target are skipped. **Recommended** variant.

### `startProcessAtElementViaMessage(messageName, correlationId, targetElement, variables)`
Starts via the message start event and then moves the token to the target:
1. `newCorrelateMessageCommand()` — starts the instance and returns the `processInstanceKey` synchronously (unlike `publishMessage`).
2. Once the instance has settled at a stable wait state, `newModifyProcessInstanceCommand(...).moveElementsWithInferredAncestor(source, target)` moves the token.

The move is issued **by element id** (the engine resolves live element instances), with a retry + stability check to absorb the eventual consistency of the element-instance search — this avoids the stale-instance-key race that `terminateElement(key)` ran into.

## Notes / design rationale
- Both mechanisms (start instructions, process instance modification) are Camunda intervention / test tools, not meant for regular production use. Variables that skipped tasks would normally set must be passed in, otherwise downstream gateways / IO-mappings may raise incidents.
- Demo usage added in `MembershipProcessAdapter` (`startAtConfirmationViaDefinition` / `startAtConfirmationViaMessage`).

## Tests
Added two `@CamundaSpringProcessTest` cases in `MiraveloMembershipProcessTest` covering both paths.

```
./gradlew :services:common-zeebe:test :services:example-service:test   # BUILD SUCCESSFUL
```