### PR TITLE
build(deps): migrate bpmn-to-code to 3.0.0 (io.miragon)

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -25,15 +25,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # Step 4: easy-zeebe serves as a beta-test bed for the bpmn-to-code plugin.
-      # New plugin versions are validated here before being published to the Gradle Plugin Portal,
-      # so we build and install the plugin from source into maven local.
-      - name: Install bpmn-to-code Gradle plugin from source (pre-release)
-        run: |
-          git clone --depth 1 https://github.com/emaarco/bpmn-to-code.git /tmp/bpmn-to-code
-          cd /tmp/bpmn-to-code
-          ./gradlew publishToMavenLocal
-
-      # Step 5: Run Gradle build
+      # Step 4: Run Gradle build
       - name: Run Gradle Build
         run: ./gradlew build

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ zeebe_version = "8.9.6"
 testcontainers_version = "2.0.5"
 postgres_version = "42.7.11"
 konsist_version = "0.17.3"
-bpmn_to_code_version = "2.2.0"
+bpmn_to_code_version = "3.0.0"
 
 [libraries]
 web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring_version" }
@@ -19,7 +19,7 @@ devtools = { module = "org.springframework.boot:spring-boot-devtools", version.r
 jpa = { module = 'org.springframework.boot:spring-boot-starter-data-jpa', version.ref = 'spring_version' }
 postgres = { module = 'org.postgresql:postgresql', version.ref = 'postgres_version' }
 zeebeSdk = { module = "io.camunda:camunda-spring-boot-starter", version.ref = "zeebe_version" }
-bpmnToCodeRuntime = { module = "io.github.emaarco:bpmn-to-code-runtime", version.ref = "bpmn_to_code_version" }
+bpmnToCodeRuntime = { module = "io.miragon:bpmn-to-code-runtime", version.ref = "bpmn_to_code_version" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.0" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin_version" }
 kotlin_logging = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "kotlin_logging_version" }
@@ -48,5 +48,5 @@ kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin_ver
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin_version" }
 springframework = { id = "org.springframework.boot", version.ref = "spring_version" }
 spring-dependency = { id = "io.spring.dependency-management", version.ref = "spring_dependency_version" }
-bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version.ref = "bpmn_to_code_version" }
+bpmnToCode = { id = "io.miragon.bpmn-to-code-gradle", version.ref = "bpmn_to_code_version" }
 gradleRetryTesting = { id = "org.gradle.test-retry", version = "1.6.5" }

--- a/services/common-zeebe-test/src/main/kotlin/io/miragon/common/test/assertions/CamundaAssertExtensions.kt
+++ b/services/common-zeebe-test/src/main/kotlin/io/miragon/common/test/assertions/CamundaAssertExtensions.kt
@@ -1,7 +1,7 @@
 package io.miragon.common.test.assertions
 
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert
-import io.github.emaarco.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.ElementId
 
 fun ProcessInstanceAssert.hasCompletedElements(vararg elements: ElementId): ProcessInstanceAssert =
     hasCompletedElements(*elements.map { it.value }.toTypedArray())

--- a/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
+++ b/services/common-zeebe/src/main/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApi.kt
@@ -1,8 +1,8 @@
 package io.miragon.common.zeebe.engine
 
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import io.miragon.common.zeebe.context.EventualConsistent
 import io.miragon.common.zeebe.context.StronglyConsistent
 import io.camunda.client.CamundaClient

--- a/services/common-zeebe/src/test/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApiTest.kt
+++ b/services/common-zeebe/src/test/kotlin/io/miragon/common/zeebe/engine/ProcessEngineApiTest.kt
@@ -2,9 +2,9 @@ package io.miragon.common.zeebe.engine
 
 import io.camunda.client.CamundaClient
 import io.camunda.client.api.response.ProcessInstanceEvent
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/services/example-service/build.gradle.kts
+++ b/services/example-service/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlin.jvm)

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
@@ -3,15 +3,15 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.SignalName
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.SignalName
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
+++ b/services/example-service/src/test/kotlin/io/miragon/example/adapter/outbound/zeebe/MembershipProcessAdapterTest.kt
@@ -9,7 +9,7 @@ import io.camunda.client.api.search.filter.UserTaskFilter
 import io.camunda.client.api.search.request.UserTaskSearchRequest
 import io.camunda.client.api.search.response.SearchResponse
 import io.camunda.client.api.search.response.UserTask
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.VariableName
 import io.miragon.common.zeebe.engine.ProcessEngineApi
 import io.miragon.example.adapter.process.MiraveloMembershipProcessApi
 import io.miragon.example.domain.MembershipId


### PR DESCRIPTION
## What

Migrates `bpmn-to-code` from version 2.2.0 to **3.0.0**.

As of 3.0.0 the project moved its home from `io.github.emaarco` to `io.miragon`
(see https://github.com/Miragon/bpmn-to-code). This is the breaking change that
3.0.0 introduces — coordinates and package names only; the task API is unchanged.

## Changes

- **Runtime dependency**: `io.github.emaarco:bpmn-to-code-runtime` → `io.miragon:bpmn-to-code-runtime`
- **Gradle plugin id**: `io.github.emaarco.bpmn-to-code-gradle` → `io.miragon.bpmn-to-code-gradle`
- **Version**: `2.2.0` → `3.0.0`
- **Imports**: `io.github.emaarco.bpmn.*` → `io.miragon.bpmn.*` across all modules
  (runtime types, the Gradle task classes, and the generated `MiraveloMembershipProcessApi`)

The unrelated internal `de.emaarco.konsist` package (our own architecture-test
package, not part of the library) was intentionally left untouched.

## Verification

- `./gradlew clean :services:example-service:generateBpmnModelApi build` → **BUILD SUCCESSFUL**
- All module tests pass; the BPMN model was regenerated with the 3.0.0 plugin.