### PR TITLE
ci(bpmn): log models under test in lint-bpmn action

### DIFF
--- a/.github/workflows/lint-bpmn-models.yml
+++ b/.github/workflows/lint-bpmn-models.yml
@@ -34,4 +34,8 @@ jobs:
       # Step 5: Lint BPMN models (fails the build on any error)
       - name: Lint BPMN models
         working-directory: tools
-        run: npm run lint:bpmn
+        run: |
+          echo "BPMN models under test:"
+          find ../services -path '*/src/main/resources/bpmn/*.bpmn'
+          echo "Total: $(find ../services -path '*/src/main/resources/bpmn/*.bpmn' | wc -l | tr -d ' ') model(s)"
+          npm run lint:bpmn

--- a/docs/bpmn-quality-gates/README.md
+++ b/docs/bpmn-quality-gates/README.md
@@ -28,6 +28,35 @@ shape slip through. Two small in-repo custom rules — `local/no-crossing-flows`
 [`probes.md`](./probes.md#custom-layout-rules) and
 [`tools/bpmnlint-plugin-local/`](../../tools/bpmnlint-plugin-local).)
 
+## In CI
+
+The geometric net is cheap and deterministic, so it runs on **every pull request** — not just
+on the agent's machine. The [`lint-bpmn-models`](../../.github/workflows/lint-bpmn-models.yml)
+workflow fires on PRs targeting `main` and is the backstop for the one failure mode this whole
+folder is about: a layout bug invisible in the XML diff slips past human review precisely because
+a reviewer reads the diff, not the rendered picture. A red check is impossible to miss; a subtly
+broken diagram in a diff is easy to wave through. The job:
+
+1. **Pins dependencies** (`miragon/pin-npm-dependencies`) — the lint result must be reproducible,
+   so a floating transitive bump can't silently change what the rules catch. See the
+   [package.json version-pinning convention](../../tools/package.json).
+2. **Installs the `tools/` toolchain** (`npm ci` against the committed lockfile), then logs the
+   models under test and runs `npm run lint:bpmn`.
+
+bpmnlint prints **nothing** on a clean run and has no file-count output, so a green job would
+otherwise be silent about what it checked. The lint step therefore `find`s and counts the models
+before invoking the linter — so the log always shows what was actually under test:
+
+```
+BPMN models under test:
+../services/example-service/src/main/resources/bpmn/membership.bpmn
+Total: 1 model(s)
+```
+
+The visual review (`/verify-model-visually`) is **not** in CI — it needs a multimodal model and
+human-style judgment, so it stays a local, agent-driven gate. CI owns only what a coordinate
+formula can settle.
+
 ## The probes
 
 Four copies of the membership model, each isolating one failure so you can see which net


### PR DESCRIPTION
## Why

The `lint-bpmn-models` GitHub Action gave no evidence of what it actually checked: `bpmnlint` prints **nothing** on a clean run and has no file-count output, so a green job looked identical whether it linted one model or none. ([example run](https://github.com/emaarco/easy-zeebe/actions/runs/28149602291/job/83364056330?pr=84))

## What

- **Workflow** — the lint step now lists the matched BPMN models and logs a total count before invoking the linter (POSIX `find`, no globstar needed; runs from `tools/`):
  ```
  BPMN models under test:
  ../services/example-service/src/main/resources/bpmn/membership.bpmn
  Total: 1 model(s)
  ```
- **Docs** — added an "In CI" section to `docs/bpmn-quality-gates/README.md` documenting *why* the action exists (PR backstop for layout bugs invisible in an XML diff), the `pin-npm-dependencies` reproducibility step, and the new logging.

## Notes

- No new files or `package.json` changes — the logging is inline in the workflow.
- Per-file pass/fail logging on clean runs is **not** included: `bpmnlint` only emits output for models with problems, which is a hard limit of its CLI. The count + path list is the practical signal.