### PR TITLE
ci(bpmn): AI visual-review gate via Claude CLI + verify-model-visually skill

### DIFF
--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -70,50 +70,78 @@ jobs:
         working-directory: tools
         run: npm ci
 
-      # Render + judge. Uses the runner's preinstalled Chrome instead of downloading
-      # Chromium (faster, no flaky postinstall). Claude writes its verdict to verdict.json.
+      # Render + judge via the Claude Code CLI. Unlike the GitHub Action, the CLI has
+      # no workflow-validation guard — so the gate runs even on the PR that changes
+      # this workflow, and the prompt can be iterated in-PR. Same OAuth secret as the
+      # action used. Uses the runner's preinstalled Chrome (no Chromium download).
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run visual review
-        uses: anthropics/claude-code-action@v1.0.140
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           PUPPETEER_SKIP_DOWNLOAD: 'true'
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash,Read,Glob,Write"'
-          prompt: |
-            Run the `verify-model-visually` skill on every BPMN model under
-            services/**/src/main/resources/bpmn/*.bpmn.
+        run: |
+          mkdir -p .context/verify
+          cat > /tmp/review-prompt.md <<'PROMPT'
+          You are the BPMN visual-review quality gate. Judge the RENDERED PICTURE of
+          each BPMN model — never the XML. Use Glob to list every model matching
+          services/**/src/main/resources/bpmn/*.bpmn and review each one.
 
-            For each model: render it to PNG with `npx bpmn-to-image` (run it from the
-            tools/ directory), then read the rendered image and
-            docs/bpmn-styleguide/styleguide.md (the Layout Guidelines section) and judge
-            the layout — visibility, overlaps, crossing flows, spacing, and label quality.
-            Review the rendered picture, never the XML.
+          Method for EACH model — follow it exactly:
 
-            Then write a single JSON file to verdict.json at the repo root with EXACTLY
-            this shape (no prose around it):
+          1. Render at HIGH resolution (subtle overlaps vanish at default scale). Run
+             npx from the tools/ directory:
+               npx bpmn-to-image --scale 3 <model>:.context/verify/<name>.png
+
+          2. The Read tool downsamples large images — which hides exactly the subtle
+             defects this gate exists to catch. So do NOT judge from the whole image.
+             Get its width with `sips -g pixelWidth <png>`, then crop it into
+             overlapping ~1200px-wide left-to-right sections and Read EACH crop:
+               sips -c <fullHeight> 1200 --cropOffset 0 <leftX> <png> --out <crop>
+             Inspect every section closely before concluding.
+
+          3. Read docs/bpmn-styleguide/styleguide.md (the Layout Guidelines section).
+
+          4. Check, in order:
+             - Visibility: every element the process uses is actually drawn.
+             - Overlaps: no two shapes overlap, AND no label sits on top of a shape
+               or another label. A name/label rendered over a task or event IS an
+               overlap — look carefully for faint text behind a shape's own label.
+             - Crossing flows, and flows routed through a shape.
+             - Spacing, alignment, and label legibility.
+
+          Severity:
+             - high  = invisible/undrawn element, ANY shape-or-label overlap, or a
+               flow crossing/through a shape. These are the defects the deterministic
+               linter can miss — the whole reason this gate exists.
+             - medium/low = cosmetic spacing, routing length, naming-style nits.
+
+          Write TWO files at the repo root and post nothing yourself:
+
+            verdict.json — EXACTLY this shape, no prose around it:
               {
                 "verdict": "pass" | "fail",
                 "findings": [
-                  {
-                    "model": "<bpmn file path>",
-                    "element": "<element or flow name>",
-                    "issue": "<what is wrong>",
-                    "rule": "<styleguide rule>",
-                    "severity": "high" | "medium" | "low"
-                  }
+                  { "model": "<path>", "element": "<name>", "issue": "<what>",
+                    "rule": "<styleguide rule>", "severity": "high|medium|low" }
                 ]
               }
+            Set "verdict" to "fail" if and only if at least one finding is "high".
 
-            Set "verdict" to "fail" ONLY if at least one finding has severity "high"
-            (e.g. an invisible/undrawn element, a shape overlap, or a flow crossing a
-            shape that the linter somehow missed). Cosmetic spacing/label issues are
-            "medium" or "low" and must NOT fail the verdict.
+            verdict.md — a short human-readable markdown summary (the verdict plus a
+            findings table) suitable to post verbatim as a PR comment.
+          PROMPT
+          claude -p "$(cat /tmp/review-prompt.md)" \
+            --allowedTools "Bash Read Glob Write" \
+            --dangerously-skip-permissions
 
-            Finally, post a short summary comment on the PR with the findings.
-
-      # Deterministic enforcement: the pipeline decision stays in our hands, not the model's.
+      # Deterministic enforcement + PR comment: the pipeline decision and the posting
+      # stay with us, not the model. Fails closed if no verdict.json was produced.
       - name: Enforce verdict
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ ! -f verdict.json ]; then
             echo "::error::The visual review produced no verdict.json — treating as failure."
@@ -122,6 +150,10 @@ jobs:
           echo "Verdict file:"
           cat verdict.json
           echo
+
+          if [ -f verdict.md ]; then
+            gh pr comment "${{ github.event.pull_request.number }}" -F verdict.md || true
+          fi
 
           jq -r '.findings[]? | "::warning::[\(.severity)] \(.model) — \(.element): \(.issue) (\(.rule))"' verdict.json
 

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -95,8 +95,19 @@ jobs:
             flow crossing or routed through a shape. Cosmetic spacing, routing length,
             and naming nits are medium/low and must not fail the verdict.
 
-            verdict.md — a short human-readable markdown summary (the verdict plus a
-            findings table) suitable to post verbatim as a PR comment.
+            verdict.md — use EXACTLY this template every time, so the posted comment
+            always looks the same. Fill in the values; add no extra sections or prose:
+
+              ## BPMN Visual Review
+
+              **Verdict:** <✅ PASS | ❌ FAIL>
+
+              | Severity | Model | Element | Issue | Rule |
+              | --- | --- | --- | --- | --- |
+              | <one row per finding, ordered high → low> |
+
+              If there are no findings, use a single row:
+              | – | – | – | No issues found. | – |
           PROMPT
           claude -p "$(cat /tmp/review-prompt.md)" \
             --allowedTools "Bash Read Glob Write Skill" \

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -39,7 +39,7 @@ jobs:
           find ../services -path '*/src/main/resources/bpmn/*.bpmn'
           set +e
           set -o pipefail
-          npm run lint:bpmn 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g' | tee /tmp/lint-report.txt
+          npm run --silent lint:bpmn 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g' | tee /tmp/lint-report.txt
           code=$?
           {
             echo 'report<<LINTEOF'

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -204,5 +204,6 @@ jobs:
           } > /tmp/comment.md
 
           PR="${{ github.event.pull_request.number }}"
-          gh pr comment "$PR" --edit-last -F /tmp/comment.md \
-            || gh pr comment "$PR" -F /tmp/comment.md
+          REPO="${{ github.repository }}"
+          gh pr comment "$PR" -R "$REPO" --edit-last -F /tmp/comment.md \
+            || gh pr comment "$PR" -R "$REPO" -F /tmp/comment.md

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -3,26 +3,21 @@ name: BPMN quality gates
 on:
   pull_request:
     branches: [ main ]
-    # Both gates only run when a BPMN model actually changed in the PR.
     paths:
       - 'services/**/src/main/resources/bpmn/*.bpmn'
 
 jobs:
-  # Gate 1 — deterministic geometry checks (bpmnlint). Hard gate: any error fails.
   lint-bpmn:
     name: Lint BPMN models (geometry)
     runs-on: ubuntu-24.04
 
     steps:
-      # Step 1: Checkout code
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      # Step 2: Fail the build if any npm dependency is not pinned to an exact version
       - name: Verify Pinned Dependencies
         uses: miragon/pin-npm-dependencies@v1
 
-      # Step 3: Set up Node.js (npm tooling lives in tools/)
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
@@ -30,12 +25,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tools/package-lock.json
 
-      # Step 4: Install dependencies (bpmnlint)
       - name: Install Dependencies
         working-directory: tools
         run: npm ci
 
-      # Step 5: Lint BPMN models (fails the build on any error)
       - name: Lint BPMN models
         working-directory: tools
         run: |
@@ -44,8 +37,6 @@ jobs:
           echo "Total: $(find ../services -path '*/src/main/resources/bpmn/*.bpmn' | wc -l | tr -d ' ') model(s)"
           npm run lint:bpmn
 
-  # Gate 2 — AI visual judgment (verify-model-visually skill). Soft gate: fails only on
-  # high-severity findings; medium/low are reported as warnings + a PR comment.
   visual-review:
     name: Visual review (AI judgment)
     needs: lint-bpmn
@@ -70,10 +61,6 @@ jobs:
         working-directory: tools
         run: npm ci
 
-      # Render + judge via the Claude Code CLI. Unlike the GitHub Action, the CLI has
-      # no workflow-validation guard — so the gate runs even on the PR that changes
-      # this workflow, and the prompt can be iterated in-PR. Same OAuth secret as the
-      # action used. Uses the runner's preinstalled Chrome (no Chromium download).
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
@@ -137,8 +124,6 @@ jobs:
             --allowedTools "Bash Read Glob Write" \
             --dangerously-skip-permissions
 
-      # Deterministic enforcement + PR comment: the pipeline decision and the posting
-      # stay with us, not the model. Fails closed if no verdict.json was produced.
       - name: Enforce verdict
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -70,42 +70,17 @@ jobs:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: |
-          mkdir -p .context/verify
           cat > /tmp/review-prompt.md <<'PROMPT'
-          You are the BPMN visual-review quality gate. Judge the RENDERED PICTURE of
-          each BPMN model — never the XML. Use Glob to list every model matching
-          services/**/src/main/resources/bpmn/*.bpmn and review each one.
+          Review every BPMN model under services/**/src/main/resources/bpmn/*.bpmn
+          for visual / layout defects.
 
-          Method for EACH model — follow it exactly:
+          Use the `verify-model-visually` skill (invoke it via the Skill tool) to do
+          the actual review — it owns the method: render the model, inspect the
+          rendered picture, and check it against the styleguide. Apply it to each
+          model. Do not reimplement the method here; rely on the skill.
 
-          1. Render at HIGH resolution (subtle overlaps vanish at default scale). Run
-             npx from the tools/ directory:
-               npx bpmn-to-image --scale 3 <model>:.context/verify/<name>.png
-
-          2. The Read tool downsamples large images — which hides exactly the subtle
-             defects this gate exists to catch. So do NOT judge from the whole image.
-             Get its width with `sips -g pixelWidth <png>`, then crop it into
-             overlapping ~1200px-wide left-to-right sections and Read EACH crop:
-               sips -c <fullHeight> 1200 --cropOffset 0 <leftX> <png> --out <crop>
-             Inspect every section closely before concluding.
-
-          3. Read docs/bpmn-styleguide/styleguide.md (the Layout Guidelines section).
-
-          4. Check, in order:
-             - Visibility: every element the process uses is actually drawn.
-             - Overlaps: no two shapes overlap, AND no label sits on top of a shape
-               or another label. A name/label rendered over a task or event IS an
-               overlap — look carefully for faint text behind a shape's own label.
-             - Crossing flows, and flows routed through a shape.
-             - Spacing, alignment, and label legibility.
-
-          Severity:
-             - high  = invisible/undrawn element, ANY shape-or-label overlap, or a
-               flow crossing/through a shape. These are the defects the deterministic
-               linter can miss — the whole reason this gate exists.
-             - medium/low = cosmetic spacing, routing length, naming-style nits.
-
-          Write TWO files at the repo root and post nothing yourself:
+          Then, based on the skill's findings, write TWO files at the repo root and
+          post nothing yourself:
 
             verdict.json — EXACTLY this shape, no prose around it:
               {
@@ -115,18 +90,33 @@ jobs:
                     "rule": "<styleguide rule>", "severity": "high|medium|low" }
                 ]
               }
-            Set "verdict" to "fail" if and only if at least one finding is "high".
+            Set "verdict" to "fail" if and only if at least one finding is high
+            severity — an invisible/undrawn element, any shape-or-label overlap, or a
+            flow crossing or routed through a shape. Cosmetic spacing, routing length,
+            and naming nits are medium/low and must not fail the verdict.
 
             verdict.md — a short human-readable markdown summary (the verdict plus a
             findings table) suitable to post verbatim as a PR comment.
           PROMPT
           claude -p "$(cat /tmp/review-prompt.md)" \
-            --allowedTools "Bash Read Glob Write" \
+            --allowedTools "Bash Read Glob Write Skill" \
             --dangerously-skip-permissions
 
-      - name: Enforce verdict
+      - name: Post review comment
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -f verdict.md ]; then
+            echo "No verdict.md produced — nothing to post."
+            exit 0
+          fi
+          PR="${{ github.event.pull_request.number }}"
+          # Overwrite our previous review comment if one exists; otherwise create it.
+          gh pr comment "$PR" --edit-last -F verdict.md \
+            || gh pr comment "$PR" -F verdict.md
+
+      - name: Enforce verdict
         run: |
           if [ ! -f verdict.json ]; then
             echo "::error::The visual review produced no verdict.json — treating as failure."
@@ -135,10 +125,6 @@ jobs:
           echo "Verdict file:"
           cat verdict.json
           echo
-
-          if [ -f verdict.md ]; then
-            gh pr comment "${{ github.event.pull_request.number }}" -F verdict.md || true
-          fi
 
           jq -r '.findings[]? | "::warning::[\(.severity)] \(.model) — \(.element): \(.issue) (\(.rule))"' verdict.json
 

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -10,6 +10,8 @@ jobs:
   lint-bpmn:
     name: Lint BPMN models (geometry)
     runs-on: ubuntu-24.04
+    outputs:
+      report: ${{ steps.lint.outputs.report }}
 
     steps:
       - name: Checkout Code
@@ -30,12 +32,21 @@ jobs:
         run: npm ci
 
       - name: Lint BPMN models
+        id: lint
         working-directory: tools
         run: |
           echo "BPMN models under test:"
           find ../services -path '*/src/main/resources/bpmn/*.bpmn'
-          echo "Total: $(find ../services -path '*/src/main/resources/bpmn/*.bpmn' | wc -l | tr -d ' ') model(s)"
-          npm run lint:bpmn
+          set +e
+          set -o pipefail
+          npm run lint:bpmn 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g' | tee /tmp/lint-report.txt
+          code=$?
+          {
+            echo 'report<<LINTEOF'
+            cat /tmp/lint-report.txt
+            echo LINTEOF
+          } >> "$GITHUB_OUTPUT"
+          exit $code
 
   visual-review:
     name: Visual review (AI judgment)
@@ -43,8 +54,10 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: write
       id-token: write
+    outputs:
+      verdict: ${{ steps.collect.outputs.verdict }}
+      summary: ${{ steps.collect.outputs.summary }}
 
     steps:
       - name: Checkout Code
@@ -101,8 +114,6 @@ jobs:
             name and whose target is the repo-relative path — not the full path as
             text — e.g. [membership.bpmn](services/example-service/src/main/resources/bpmn/membership.bpmn).
 
-              ## BPMN Visual Review
-
               **Verdict:** <✅ PASS | ❌ FAIL>
 
               | Severity | Model | Element | Issue | Rule |
@@ -116,19 +127,17 @@ jobs:
             --allowedTools "Bash Read Glob Write Skill" \
             --dangerously-skip-permissions
 
-      - name: Post review comment
+      - name: Collect results
+        id: collect
         if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -f verdict.md ]; then
-            echo "No verdict.md produced — nothing to post."
-            exit 0
-          fi
-          PR="${{ github.event.pull_request.number }}"
-          # Overwrite our previous review comment if one exists; otherwise create it.
-          gh pr comment "$PR" --edit-last -F verdict.md \
-            || gh pr comment "$PR" -F verdict.md
+          verdict=$(jq -r '.verdict' verdict.json 2>/dev/null || echo error)
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          {
+            echo 'summary<<SUMEOF'
+            if [ -f verdict.md ]; then cat verdict.md; else echo "_No verdict produced._"; fi
+            echo SUMEOF
+          } >> "$GITHUB_OUTPUT"
 
       - name: Enforce verdict
         run: |
@@ -148,3 +157,52 @@ jobs:
             exit 1
           fi
           echo "✅ Visual review passed."
+
+  post-comment:
+    name: Post quality-gates comment
+    needs: [ lint-bpmn, visual-review ]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Build and post sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINT_RESULT: ${{ needs.lint-bpmn.result }}
+          LINT_REPORT: ${{ needs.lint-bpmn.outputs.report }}
+          VIS_RESULT: ${{ needs.visual-review.result }}
+          VIS_SUMMARY: ${{ needs.visual-review.outputs.summary }}
+        run: |
+          {
+            echo "## BPMN quality gates"
+            echo
+
+            if [ "$LINT_RESULT" = "success" ]; then
+              echo "### Geometry (bpmnlint) — ✅ passed"
+            elif [ "$LINT_RESULT" = "failure" ]; then
+              echo "### Geometry (bpmnlint) — ❌ failed"
+              echo
+              echo '```'
+              printf '%s\n' "$LINT_REPORT"
+              echo '```'
+            else
+              echo "### Geometry (bpmnlint) — ⤼ $LINT_RESULT"
+            fi
+            echo
+
+            echo "### Visual review (AI judgment)"
+            echo
+            if [ "$VIS_RESULT" = "skipped" ]; then
+              echo "⤼ skipped — the geometry gate failed; fix that first."
+            elif [ -n "$VIS_SUMMARY" ]; then
+              printf '%s\n' "$VIS_SUMMARY"
+            else
+              echo "⚠️ no result produced."
+            fi
+          } > /tmp/comment.md
+
+          PR="${{ github.event.pull_request.number }}"
+          gh pr comment "$PR" --edit-last -F /tmp/comment.md \
+            || gh pr comment "$PR" -F /tmp/comment.md

--- a/.github/workflows/bpmn-quality-gates.yml
+++ b/.github/workflows/bpmn-quality-gates.yml
@@ -96,7 +96,10 @@ jobs:
             and naming nits are medium/low and must not fail the verdict.
 
             verdict.md — use EXACTLY this template every time, so the posted comment
-            always looks the same. Fill in the values; add no extra sections or prose:
+            always looks the same. Fill in the values; add no extra sections or prose.
+            In the Model column put ONLY a markdown link whose text is the bare file
+            name and whose target is the repo-relative path — not the full path as
+            text — e.g. [membership.bpmn](services/example-service/src/main/resources/bpmn/membership.bpmn).
 
               ## BPMN Visual Review
 
@@ -104,7 +107,7 @@ jobs:
 
               | Severity | Model | Element | Issue | Rule |
               | --- | --- | --- | --- | --- |
-              | <one row per finding, ordered high → low> |
+              | <one row per finding, ordered high → low; Model = [name](path)> |
 
               If there are no findings, use a single row:
               | – | – | – | No issues found. | – |

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -156,7 +156,7 @@
       <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="420" y="276" width="65" height="27" />
+          <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -181,7 +181,7 @@
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
-        <dc:Bounds x="810" y="293" width="100" height="80" />
+        <dc:Bounds x="720" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -156,7 +156,7 @@
       <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="158" y="355" width="65" height="27" />
+          <dc:Bounds x="420" y="276" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -156,7 +156,7 @@
       <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="158" y="355" width="65" height="27" />
+          <dc:Bounds x="288" y="318" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -156,7 +156,7 @@
       <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="288" y="318" width="65" height="27" />
+          <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -156,7 +156,7 @@
       <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="420" y="276" width="65" height="27" />
+          <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
@@ -181,7 +181,7 @@
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
-        <dc:Bounds x="720" y="293" width="100" height="80" />
+        <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />


### PR DESCRIPTION
Adds the AI visual-review gate (gate 2) to the BPMN quality-gates workflow, alongside the deterministic `bpmnlint` gate.

## How
- **Runs via the Claude Code CLI** in a plain `run` step (not the GitHub Action) — the action self-skips whenever the workflow file differs from the default branch (its workflow-validation guard), so the gate could never run on the PR that introduces or tweaks it. The CLI has no such guard.
- **Drives the `verify-model-visually` skill** (Skill tool in `--allowedTools`) as the single source of truth for the review method — no duplicated logic in the workflow.
- **Separate `Post review comment` step**, decoupled from pass/fail gating. Uses `--edit-last` to overwrite the previous bot comment instead of opening a new thread each run.
- **Fixed `verdict.md` template** so every posted comment looks identical run-to-run.
- **Soft gate**: `Enforce verdict` fails only on a high-severity finding (`verdict: fail`); medium/low surface as warnings. Same `CLAUDE_CODE_OAUTH_TOKEN` secret as before.

Net change vs `main` is the workflow file only; the demo model overlap used during testing has been reverted.

## Known limitation
AI judgment is non-deterministic — across test runs the same subtle overlap was caught as high in some runs and rated low in others. The gate is therefore a backstop, not a precise detector; `bpmnlint` remains the strict deterministic gate. Switching gate 2 to advisory-only (drop the `exit 1`) is a one-line change if preferred.