### PR TITLE
chore(conductor): configure workspace lifecycle with docker-compose stack

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -16,3 +16,11 @@ icon = "flame"
 [scripts.run.test]
 command = "./gradlew test"
 icon = "test-tube"
+
+# End-to-end smoke test against a running backend: fires the Bruno happy-path
+# requests (register -> process-instances -> confirm) in sequence with a 3s delay
+# between each, giving the async process time to advance. Excludes the reject path.
+# Requires the `backend` target to be running first.
+[scripts.run.smoke]
+command = "cd bruno && npx --yes @usebruno/cli run --delay 3000 --exclude-tags reject --bail"
+icon = "activity"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,18 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "npm --prefix tools install && npm --prefix tools run hooks:install"
+run_mode = "nonconcurrent"
+archive = "cd stack && docker compose down"
+
+[scripts.run.infra]
+command = "cd stack && docker compose up"
+icon = "database"
+
+[scripts.run.backend]
+command = "cd stack && docker compose up -d --wait && cd .. && ./gradlew :services:example-service:bootRun"
+icon = "flame"
+
+[scripts.run.test]
+command = "./gradlew test"
+icon = "test-tube"

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -17,10 +17,6 @@ icon = "flame"
 command = "./gradlew test"
 icon = "test-tube"
 
-# End-to-end smoke test against a running backend: fires the Bruno happy-path
-# requests (register -> process-instances -> confirm) in sequence with a 3s delay
-# between each, giving the async process time to advance. Excludes the reject path.
-# Requires the `backend` target to be running first.
 [scripts.run.smoke]
 command = "cd bruno && npx --yes @usebruno/cli run --delay 3000 --exclude-tags reject --bail"
 icon = "activity"

--- a/bruno/confirm-membership.bru
+++ b/bruno/confirm-membership.bru
@@ -1,7 +1,7 @@
 meta {
   name: Confirm Membership
   type: http
-  seq: 3
+  seq: 4
 }
 
 post {
@@ -12,4 +12,8 @@ post {
 
 params:path {
   membershipId: {{membershipId}}
+}
+
+assert {
+  res.status: eq 200
 }

--- a/bruno/process-instances.bru
+++ b/bruno/process-instances.bru
@@ -14,3 +14,7 @@ settings {
   encodeUrl: true
   timeout: 0
 }
+
+assert {
+  res.status: eq 200
+}

--- a/bruno/register-membership.bru
+++ b/bruno/register-membership.bru
@@ -21,3 +21,8 @@ body:json {
 vars:post-response {
   membershipId: res.body.membershipId
 }
+
+assert {
+  res.status: eq 200
+  res.body.membershipId: isDefined
+}

--- a/bruno/reject-confirmation.bru
+++ b/bruno/reject-confirmation.bru
@@ -1,7 +1,10 @@
 meta {
   name: Reject Confirmation
   type: http
-  seq: 4
+  seq: 5
+  tags: [
+    reject
+  ]
 }
 
 post {


### PR DESCRIPTION
Adds `.conductor/settings.toml` to configure the full Conductor workspace lifecycle: setup installs the BPMN tooling and pre-commit hook, and archive tears down the shared docker-compose stack on cleanup. Four selectable run targets are exposed with no default (nothing autostarts): `infra` (foreground stack), `backend` (brings the stack up with `--wait`, then `bootRun`), `test` (Gradle), and `smoke`. `run_mode` is `nonconcurrent` because the stack and backend bind fixed ports and container names. The `smoke` target runs the Bruno happy-path requests (register → process-instances → confirm) in sequence against a running backend with a 3s delay between each, so it needs `backend` running first. To make it a reliable pass/fail check, the Bruno collection now has status/body assertions, deterministic `seq` ordering, and a tag on the reject path so the smoke run excludes it.