### PR TITLE
feat(bpmn): add styleguide id/name lint rules and adopt camelCase ids

### DIFF
--- a/.claude/skills/review-process/SKILL.md
+++ b/.claude/skills/review-process/SKILL.md
@@ -39,7 +39,7 @@ If you found a matching file, read the file and extract:
 
 Read `docs/bpmn-styleguide/styleguide.md`. Extract the conventions for:
 
-- **Element ID format**: `Type_Name` in CamelCase (e.g. `serviceTask_SendWelcomeMail`)
+- **Element ID format**: `type_name` in lowerCamelCase (e.g. `serviceTask_sendWelcomeMail`)
 - **Message ID format**: `<serviceName>.<state>` — both parts CamelCase (e.g. `newsletter.subscriptionConfirmed`)
 - **Type ID format**: `<serviceName>.<elementIdWithoutTypePrefix>` — both parts CamelCase (e.g.
   `newsletter.sendWelcomeMail`)

--- a/.claude/skills/test-process/SKILL.md
+++ b/.claude/skills/test-process/SKILL.md
@@ -51,7 +51,7 @@ class NewsletterProcessTest {
         val instanceKey = processPort.startNewsletterSubscription(NewsletterSubscriptionId("uuid-1"))
         val selector = ProcessInstanceSelectors.byKey(instanceKey)
 
-        CamundaAssert.assertThat(selector).hasCompletedElement("serviceTask_Subscribe")
+        CamundaAssert.assertThat(selector).hasCompletedElement("serviceTask_subscribe")
         verify { subscribeUseCase.execute(any()) }
         confirmVerified(subscribeUseCase)
     }

--- a/docs/bpmn-quality-gates/probes/clean/clean.bpmn
+++ b/docs/bpmn-quality-gates/probes/clean/clean.bpmn
@@ -12,277 +12,277 @@
   </bpmn:message>
   <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
+    <bpmn:startEvent id="startEvent_membershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:outgoing>flow_startToClaim</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
-    <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
+    <bpmn:serviceTask id="serviceTask_claimMembership" name="Claim Membership">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.claimMembership" />
         <zeebe:ioMapping>
           <zeebe:output source="=hasEmptySpots" target="hasEmptySpots" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_start_to_claim</bpmn:incoming>
-      <bpmn:outgoing>Flow_claim_to_gateway</bpmn:outgoing>
+      <bpmn:incoming>flow_startToClaim</bpmn:incoming>
+      <bpmn:outgoing>flow_claimToGateway</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="gateway_HasEmptySpots" name="Has empty&#10;spots?" default="Flow_no_spots">
-      <bpmn:incoming>Flow_claim_to_gateway</bpmn:incoming>
-      <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
-      <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_hasEmptySpots" name="Has empty&#10;spots?" default="flow_noSpots">
+      <bpmn:incoming>flow_claimToGateway</bpmn:incoming>
+      <bpmn:outgoing>flow_yesSpots</bpmn:outgoing>
+      <bpmn:outgoing>flow_noSpots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
-      <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
-      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
-        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+    <bpmn:subProcess id="subProcess_confirmMembership" name="Confirm Membership">
+      <bpmn:incoming>flow_yesSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_subProcessToWelcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_confirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>flow_subStartToConfirmationMail</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+      <bpmn:serviceTask id="serviceTask_sendConfirmationMail" name="Send&#10;Confirmation Mail">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
-        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+        <bpmn:incoming>flow_subStartToConfirmationMail</bpmn:incoming>
+        <bpmn:outgoing>flow_confirmationMailToUserTask</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+      <bpmn:userTask id="userTask_confirmMembership" name="Confirm Membership">
         <bpmn:extensionElements>
           <zeebe:userTask />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
-        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+        <bpmn:incoming>flow_confirmationMailToUserTask</bpmn:incoming>
+        <bpmn:outgoing>flow_userTaskToSubEnd</bpmn:outgoing>
       </bpmn:userTask>
-      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
-        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      <bpmn:endEvent id="endEvent_membershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>flow_userTaskToSubEnd</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
-      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
-      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+      <bpmn:sequenceFlow id="flow_subStartToConfirmationMail" sourceRef="startEvent_confirmationRequired" targetRef="serviceTask_sendConfirmationMail" />
+      <bpmn:sequenceFlow id="flow_confirmationMailToUserTask" sourceRef="serviceTask_sendConfirmationMail" targetRef="userTask_confirmMembership" />
+      <bpmn:sequenceFlow id="flow_userTaskToSubEnd" sourceRef="userTask_confirmMembership" targetRef="endEvent_membershipConfirmed" />
     </bpmn:subProcess>
-    <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
+    <bpmn:serviceTask id="serviceTask_sendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
+      <bpmn:incoming>flow_subProcessToWelcome</bpmn:incoming>
+      <bpmn:outgoing>flow_welcomeToActivated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
-      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>flow_welcomeToActivated</bpmn:incoming>
       <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
+    <bpmn:serviceTask id="serviceTask_sendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendRejectionMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_no_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_noSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_rejectionToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
-      <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipRejected" name="Membership&#10;rejected">
+      <bpmn:incoming>flow_rejectionToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_reminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timerToReSend</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+    <bpmn:serviceTask id="serviceTask_reSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
-      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_timerToReSend</bpmn:incoming>
+      <bpmn:outgoing>flow_reSendToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
-      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_mailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>flow_reSendToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_rejectedToRevoke</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timeoutToRevoke</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:exclusiveGateway id="gateway_RevokeReason">
-      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
-      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_gateway_to_revoke</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_revokeReason">
+      <bpmn:incoming>flow_timeoutToRevoke</bpmn:incoming>
+      <bpmn:incoming>flow_rejectedToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_gatewayToRevoke</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+    <bpmn:serviceTask id="serviceTask_revokeMembershipRequest" name="Revoke&#10;Membership Request">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_gateway_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+      <bpmn:incoming>flow_gatewayToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_revokeToDeclined</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
-      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>flow_revokeToDeclined</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+    <bpmn:serviceTask id="serviceTask_revokeClaim" name="Revoke Claim" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeClaim" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="event_ClaimCompensation" name="Claim made" attachedToRef="serviceTask_ClaimMembership">
+    <bpmn:boundaryEvent id="event_claimCompensation" name="Claim made" attachedToRef="serviceTask_claimMembership">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
-    <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
+    <bpmn:sequenceFlow id="flow_startToClaim" sourceRef="startEvent_membershipRequested" targetRef="serviceTask_claimMembership" />
+    <bpmn:sequenceFlow id="flow_claimToGateway" sourceRef="serviceTask_claimMembership" targetRef="gateway_hasEmptySpots" />
+    <bpmn:sequenceFlow id="flow_yesSpots" name="Yes" sourceRef="gateway_hasEmptySpots" targetRef="subProcess_confirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
-    <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
-    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
-    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
-    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_gateway_to_revoke" sourceRef="gateway_RevokeReason" targetRef="serviceTask_RevokeMembershipRequest" />
-    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
-    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
+    <bpmn:sequenceFlow id="flow_noSpots" name="No" sourceRef="gateway_hasEmptySpots" targetRef="serviceTask_sendRejectionMail" />
+    <bpmn:sequenceFlow id="flow_subProcessToWelcome" sourceRef="subProcess_confirmMembership" targetRef="serviceTask_sendWelcomeMail" />
+    <bpmn:sequenceFlow id="flow_welcomeToActivated" sourceRef="serviceTask_sendWelcomeMail" targetRef="endEvent_membershipActivated" />
+    <bpmn:sequenceFlow id="flow_rejectionToEnd" sourceRef="serviceTask_sendRejectionMail" targetRef="endEvent_membershipRejected" />
+    <bpmn:sequenceFlow id="flow_timerToReSend" sourceRef="event_reminderDue" targetRef="serviceTask_reSendConfirmationMail" />
+    <bpmn:sequenceFlow id="flow_reSendToEnd" sourceRef="serviceTask_reSendConfirmationMail" targetRef="endEvent_mailSentAgain" />
+    <bpmn:sequenceFlow id="flow_timeoutToRevoke" sourceRef="event_confirmationDeadlinePassed" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_rejectedToRevoke" sourceRef="event_confirmationRejected" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_gatewayToRevoke" sourceRef="gateway_revokeReason" targetRef="serviceTask_revokeMembershipRequest" />
+    <bpmn:sequenceFlow id="flow_revokeToDeclined" sourceRef="serviceTask_revokeMembershipRequest" targetRef="endEvent_membershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_claimCompensation" targetRef="serviceTask_revokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_membershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
+      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_claimMembership">
         <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_hasEmptySpots" isMarkerVisible="true">
         <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_confirmMembership" isExpanded="true">
         <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_confirmationRequired">
         <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="569" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_sendConfirmationMail">
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_confirmMembership">
         <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_membershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="959" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+      <bpmndi:BPMNEdge id="flow_subStartToConfirmationMail_di" bpmnElement="flow_subStartToConfirmationMail">
         <di:waypoint x="618" y="333" />
         <di:waypoint x="670" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+      <bpmndi:BPMNEdge id="flow_confirmationMailToUserTask_di" bpmnElement="flow_confirmationMailToUserTask">
         <di:waypoint x="770" y="333" />
         <di:waypoint x="810" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+      <bpmndi:BPMNEdge id="flow_userTaskToSubEnd_di" bpmnElement="flow_userTaskToSubEnd">
         <di:waypoint x="910" y="333" />
         <di:waypoint x="972" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_sendWelcomeMail">
         <dc:Bounds x="1110" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_membershipActivated">
         <dc:Bounds x="1262" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
+      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_sendRejectionMail">
         <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
+      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_membershipRejected">
         <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="575" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_reSendConfirmationMail">
         <dc:Bounds x="1110" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_mailSentAgain">
         <dc:Bounds x="1262" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1252" y="575" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_RevokeReason" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_revokeReason" isMarkerVisible="true">
         <dc:Bounds x="1015" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_revokeMembershipRequest">
         <dc:Bounds x="1100" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_membershipDeclined">
         <dc:Bounds x="1262" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_revokeClaim">
         <dc:Bounds x="400" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_claimCompensation">
         <dc:Bounds x="312" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="250" y="244" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_confirmationDeadlinePassed">
         <dc:Bounds x="972" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="186" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_confirmationRejected">
         <dc:Bounds x="702" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="638" y="186" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_reminderDue">
         <dc:Bounds x="972" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
+      <bpmndi:BPMNEdge id="flow_startToClaim_di" bpmnElement="flow_startToClaim">
         <di:waypoint x="208" y="330" />
         <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
+      <bpmndi:BPMNEdge id="flow_claimToGateway_di" bpmnElement="flow_claimToGateway">
         <di:waypoint x="370" y="330" />
         <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
+      <bpmndi:BPMNEdge id="flow_yesSpots_di" bpmnElement="flow_yesSpots">
         <di:waypoint x="475" y="330" />
         <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
+      <bpmndi:BPMNEdge id="flow_noSpots_di" bpmnElement="flow_noSpots">
         <di:waypoint x="450" y="355" />
         <di:waypoint x="450" y="550" />
         <di:waypoint x="540" y="550" />
@@ -290,42 +290,42 @@
           <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+      <bpmndi:BPMNEdge id="flow_subProcessToWelcome_di" bpmnElement="flow_subProcessToWelcome">
         <di:waypoint x="1060" y="330" />
         <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+      <bpmndi:BPMNEdge id="flow_welcomeToActivated_di" bpmnElement="flow_welcomeToActivated">
         <di:waypoint x="1210" y="330" />
         <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
+      <bpmndi:BPMNEdge id="flow_rejectionToEnd_di" bpmnElement="flow_rejectionToEnd">
         <di:waypoint x="640" y="550" />
         <di:waypoint x="702" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+      <bpmndi:BPMNEdge id="flow_timerToReSend_di" bpmnElement="flow_timerToReSend">
         <di:waypoint x="990" y="458" />
         <di:waypoint x="990" y="550" />
         <di:waypoint x="1110" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+      <bpmndi:BPMNEdge id="flow_reSendToEnd_di" bpmnElement="flow_reSendToEnd">
         <di:waypoint x="1210" y="550" />
         <di:waypoint x="1262" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+      <bpmndi:BPMNEdge id="flow_timeoutToRevoke_di" bpmnElement="flow_timeoutToRevoke">
         <di:waypoint x="990" y="212" />
         <di:waypoint x="990" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+      <bpmndi:BPMNEdge id="flow_rejectedToRevoke_di" bpmnElement="flow_rejectedToRevoke">
         <di:waypoint x="720" y="212" />
         <di:waypoint x="720" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_gateway_to_revoke_di" bpmnElement="Flow_gateway_to_revoke">
+      <bpmndi:BPMNEdge id="flow_gatewayToRevoke_di" bpmnElement="flow_gatewayToRevoke">
         <di:waypoint x="1065" y="120" />
         <di:waypoint x="1100" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+      <bpmndi:BPMNEdge id="flow_revokeToDeclined_di" bpmnElement="flow_revokeToDeclined">
         <di:waypoint x="1200" y="120" />
         <di:waypoint x="1262" y="120" />
       </bpmndi:BPMNEdge>

--- a/docs/bpmn-quality-gates/probes/probe-crossing/README.md
+++ b/docs/bpmn-quality-gates/probes/probe-crossing/README.md
@@ -20,7 +20,7 @@ $ npx bpmnlint probe-crossing.bpmn
 With `local/no-crossing-flows` (error) in place:
 
 ```
-  Flow_welcome_to_activated  error  Sequence flow crosses sequence flow <Flow_reSend_to_end>  local/no-crossing-flows
+  flow_welcomeToActivated  error  Sequence flow crosses sequence flow <flow_reSendToEnd>  local/no-crossing-flows
 ✖ 1 problem (1 error, 0 warnings)                  # exit 1
 ```
 

--- a/docs/bpmn-quality-gates/probes/probe-crossing/probe-crossing.bpmn
+++ b/docs/bpmn-quality-gates/probes/probe-crossing/probe-crossing.bpmn
@@ -12,277 +12,277 @@
   </bpmn:message>
   <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
+    <bpmn:startEvent id="startEvent_membershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:outgoing>flow_startToClaim</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
-    <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
+    <bpmn:serviceTask id="serviceTask_claimMembership" name="Claim Membership">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.claimMembership" />
         <zeebe:ioMapping>
           <zeebe:output source="=hasEmptySpots" target="hasEmptySpots" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_start_to_claim</bpmn:incoming>
-      <bpmn:outgoing>Flow_claim_to_gateway</bpmn:outgoing>
+      <bpmn:incoming>flow_startToClaim</bpmn:incoming>
+      <bpmn:outgoing>flow_claimToGateway</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="gateway_HasEmptySpots" name="Has empty&#10;spots?" default="Flow_no_spots">
-      <bpmn:incoming>Flow_claim_to_gateway</bpmn:incoming>
-      <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
-      <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_hasEmptySpots" name="Has empty&#10;spots?" default="flow_noSpots">
+      <bpmn:incoming>flow_claimToGateway</bpmn:incoming>
+      <bpmn:outgoing>flow_yesSpots</bpmn:outgoing>
+      <bpmn:outgoing>flow_noSpots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
-      <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
-      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
-        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+    <bpmn:subProcess id="subProcess_confirmMembership" name="Confirm Membership">
+      <bpmn:incoming>flow_yesSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_subProcessToWelcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_confirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>flow_subStartToConfirmationMail</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+      <bpmn:serviceTask id="serviceTask_sendConfirmationMail" name="Send&#10;Confirmation Mail">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
-        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+        <bpmn:incoming>flow_subStartToConfirmationMail</bpmn:incoming>
+        <bpmn:outgoing>flow_confirmationMailToUserTask</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+      <bpmn:userTask id="userTask_confirmMembership" name="Confirm Membership">
         <bpmn:extensionElements>
           <zeebe:userTask />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
-        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+        <bpmn:incoming>flow_confirmationMailToUserTask</bpmn:incoming>
+        <bpmn:outgoing>flow_userTaskToSubEnd</bpmn:outgoing>
       </bpmn:userTask>
-      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
-        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      <bpmn:endEvent id="endEvent_membershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>flow_userTaskToSubEnd</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
-      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
-      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+      <bpmn:sequenceFlow id="flow_subStartToConfirmationMail" sourceRef="startEvent_confirmationRequired" targetRef="serviceTask_sendConfirmationMail" />
+      <bpmn:sequenceFlow id="flow_confirmationMailToUserTask" sourceRef="serviceTask_sendConfirmationMail" targetRef="userTask_confirmMembership" />
+      <bpmn:sequenceFlow id="flow_userTaskToSubEnd" sourceRef="userTask_confirmMembership" targetRef="endEvent_membershipConfirmed" />
     </bpmn:subProcess>
-    <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
+    <bpmn:serviceTask id="serviceTask_sendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
+      <bpmn:incoming>flow_subProcessToWelcome</bpmn:incoming>
+      <bpmn:outgoing>flow_welcomeToActivated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
-      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>flow_welcomeToActivated</bpmn:incoming>
       <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
+    <bpmn:serviceTask id="serviceTask_sendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendRejectionMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_no_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_noSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_rejectionToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
-      <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipRejected" name="Membership&#10;rejected">
+      <bpmn:incoming>flow_rejectionToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_reminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timerToReSend</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+    <bpmn:serviceTask id="serviceTask_reSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
-      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_timerToReSend</bpmn:incoming>
+      <bpmn:outgoing>flow_reSendToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
-      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_mailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>flow_reSendToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_rejectedToRevoke</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timeoutToRevoke</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:exclusiveGateway id="gateway_RevokeReason">
-      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
-      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_gateway_to_revoke</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_revokeReason">
+      <bpmn:incoming>flow_timeoutToRevoke</bpmn:incoming>
+      <bpmn:incoming>flow_rejectedToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_gatewayToRevoke</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+    <bpmn:serviceTask id="serviceTask_revokeMembershipRequest" name="Revoke&#10;Membership Request">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_gateway_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+      <bpmn:incoming>flow_gatewayToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_revokeToDeclined</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
-      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>flow_revokeToDeclined</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+    <bpmn:serviceTask id="serviceTask_revokeClaim" name="Revoke Claim" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeClaim" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="event_ClaimCompensation" name="Claim made" attachedToRef="serviceTask_ClaimMembership">
+    <bpmn:boundaryEvent id="event_claimCompensation" name="Claim made" attachedToRef="serviceTask_claimMembership">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
-    <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
+    <bpmn:sequenceFlow id="flow_startToClaim" sourceRef="startEvent_membershipRequested" targetRef="serviceTask_claimMembership" />
+    <bpmn:sequenceFlow id="flow_claimToGateway" sourceRef="serviceTask_claimMembership" targetRef="gateway_hasEmptySpots" />
+    <bpmn:sequenceFlow id="flow_yesSpots" name="Yes" sourceRef="gateway_hasEmptySpots" targetRef="subProcess_confirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
-    <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
-    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
-    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
-    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_gateway_to_revoke" sourceRef="gateway_RevokeReason" targetRef="serviceTask_RevokeMembershipRequest" />
-    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
-    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
+    <bpmn:sequenceFlow id="flow_noSpots" name="No" sourceRef="gateway_hasEmptySpots" targetRef="serviceTask_sendRejectionMail" />
+    <bpmn:sequenceFlow id="flow_subProcessToWelcome" sourceRef="subProcess_confirmMembership" targetRef="serviceTask_sendWelcomeMail" />
+    <bpmn:sequenceFlow id="flow_welcomeToActivated" sourceRef="serviceTask_sendWelcomeMail" targetRef="endEvent_membershipActivated" />
+    <bpmn:sequenceFlow id="flow_rejectionToEnd" sourceRef="serviceTask_sendRejectionMail" targetRef="endEvent_membershipRejected" />
+    <bpmn:sequenceFlow id="flow_timerToReSend" sourceRef="event_reminderDue" targetRef="serviceTask_reSendConfirmationMail" />
+    <bpmn:sequenceFlow id="flow_reSendToEnd" sourceRef="serviceTask_reSendConfirmationMail" targetRef="endEvent_mailSentAgain" />
+    <bpmn:sequenceFlow id="flow_timeoutToRevoke" sourceRef="event_confirmationDeadlinePassed" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_rejectedToRevoke" sourceRef="event_confirmationRejected" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_gatewayToRevoke" sourceRef="gateway_revokeReason" targetRef="serviceTask_revokeMembershipRequest" />
+    <bpmn:sequenceFlow id="flow_revokeToDeclined" sourceRef="serviceTask_revokeMembershipRequest" targetRef="endEvent_membershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_claimCompensation" targetRef="serviceTask_revokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_membershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
+      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_claimMembership">
         <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_hasEmptySpots" isMarkerVisible="true">
         <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_confirmMembership" isExpanded="true">
         <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_confirmationRequired">
         <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="569" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_sendConfirmationMail">
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_confirmMembership">
         <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_membershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="959" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+      <bpmndi:BPMNEdge id="flow_subStartToConfirmationMail_di" bpmnElement="flow_subStartToConfirmationMail">
         <di:waypoint x="618" y="333" />
         <di:waypoint x="670" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+      <bpmndi:BPMNEdge id="flow_confirmationMailToUserTask_di" bpmnElement="flow_confirmationMailToUserTask">
         <di:waypoint x="770" y="333" />
         <di:waypoint x="810" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+      <bpmndi:BPMNEdge id="flow_userTaskToSubEnd_di" bpmnElement="flow_userTaskToSubEnd">
         <di:waypoint x="910" y="333" />
         <di:waypoint x="972" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_sendWelcomeMail">
         <dc:Bounds x="1110" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_membershipActivated">
         <dc:Bounds x="1262" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
+      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_sendRejectionMail">
         <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
+      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_membershipRejected">
         <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="575" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_reSendConfirmationMail">
         <dc:Bounds x="1110" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_mailSentAgain">
         <dc:Bounds x="1262" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1252" y="575" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_RevokeReason" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_revokeReason" isMarkerVisible="true">
         <dc:Bounds x="1015" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_revokeMembershipRequest">
         <dc:Bounds x="1100" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_membershipDeclined">
         <dc:Bounds x="1262" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_revokeClaim">
         <dc:Bounds x="400" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_claimCompensation">
         <dc:Bounds x="312" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="250" y="244" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_confirmationDeadlinePassed">
         <dc:Bounds x="972" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="186" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_confirmationRejected">
         <dc:Bounds x="702" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="638" y="186" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_reminderDue">
         <dc:Bounds x="972" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
+      <bpmndi:BPMNEdge id="flow_startToClaim_di" bpmnElement="flow_startToClaim">
         <di:waypoint x="208" y="330" />
         <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
+      <bpmndi:BPMNEdge id="flow_claimToGateway_di" bpmnElement="flow_claimToGateway">
         <di:waypoint x="370" y="330" />
         <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
+      <bpmndi:BPMNEdge id="flow_yesSpots_di" bpmnElement="flow_yesSpots">
         <di:waypoint x="475" y="330" />
         <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
+      <bpmndi:BPMNEdge id="flow_noSpots_di" bpmnElement="flow_noSpots">
         <di:waypoint x="450" y="355" />
         <di:waypoint x="450" y="550" />
         <di:waypoint x="540" y="550" />
@@ -290,43 +290,43 @@
           <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+      <bpmndi:BPMNEdge id="flow_subProcessToWelcome_di" bpmnElement="flow_subProcessToWelcome">
         <di:waypoint x="1060" y="330" />
         <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+      <bpmndi:BPMNEdge id="flow_welcomeToActivated_di" bpmnElement="flow_welcomeToActivated">
         <di:waypoint x="1210" y="330" />
         <di:waypoint x="1236" y="560" />
         <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
+      <bpmndi:BPMNEdge id="flow_rejectionToEnd_di" bpmnElement="flow_rejectionToEnd">
         <di:waypoint x="640" y="550" />
         <di:waypoint x="702" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+      <bpmndi:BPMNEdge id="flow_timerToReSend_di" bpmnElement="flow_timerToReSend">
         <di:waypoint x="990" y="458" />
         <di:waypoint x="990" y="550" />
         <di:waypoint x="1110" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+      <bpmndi:BPMNEdge id="flow_reSendToEnd_di" bpmnElement="flow_reSendToEnd">
         <di:waypoint x="1210" y="550" />
         <di:waypoint x="1262" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+      <bpmndi:BPMNEdge id="flow_timeoutToRevoke_di" bpmnElement="flow_timeoutToRevoke">
         <di:waypoint x="990" y="212" />
         <di:waypoint x="990" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+      <bpmndi:BPMNEdge id="flow_rejectedToRevoke_di" bpmnElement="flow_rejectedToRevoke">
         <di:waypoint x="720" y="212" />
         <di:waypoint x="720" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_gateway_to_revoke_di" bpmnElement="Flow_gateway_to_revoke">
+      <bpmndi:BPMNEdge id="flow_gatewayToRevoke_di" bpmnElement="flow_gatewayToRevoke">
         <di:waypoint x="1065" y="120" />
         <di:waypoint x="1100" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+      <bpmndi:BPMNEdge id="flow_revokeToDeclined_di" bpmnElement="flow_revokeToDeclined">
         <di:waypoint x="1200" y="120" />
         <di:waypoint x="1262" y="120" />
       </bpmndi:BPMNEdge>

--- a/docs/bpmn-quality-gates/probes/probe-invisible/README.md
+++ b/docs/bpmn-quality-gates/probes/probe-invisible/README.md
@@ -14,7 +14,7 @@ error) flags any semantic element with no shape, so even before the custom layou
 caught:
 
 ```
-  serviceTask_SendConfirmationMail  error  Element is missing bpmndi  no-bpmndi
+  serviceTask_sendConfirmationMail  error  Element is missing bpmndi  no-bpmndi
 ✖ 1 problem (1 error, 0 warnings)                  # exit 1
 ```
 
@@ -24,7 +24,7 @@ Unchanged — the custom layout rules don't touch this case (it is a missing _sh
 edge geometry):
 
 ```
-  serviceTask_SendConfirmationMail  error  Element is missing bpmndi  no-bpmndi
+  serviceTask_sendConfirmationMail  error  Element is missing bpmndi  no-bpmndi
 ✖ 1 problem (1 error, 0 warnings)                  # exit 1
 ```
 

--- a/docs/bpmn-quality-gates/probes/probe-invisible/probe-invisible.bpmn
+++ b/docs/bpmn-quality-gates/probes/probe-invisible/probe-invisible.bpmn
@@ -12,274 +12,274 @@
   </bpmn:message>
   <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
+    <bpmn:startEvent id="startEvent_membershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:outgoing>flow_startToClaim</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
-    <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
+    <bpmn:serviceTask id="serviceTask_claimMembership" name="Claim Membership">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.claimMembership" />
         <zeebe:ioMapping>
           <zeebe:output source="=hasEmptySpots" target="hasEmptySpots" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_start_to_claim</bpmn:incoming>
-      <bpmn:outgoing>Flow_claim_to_gateway</bpmn:outgoing>
+      <bpmn:incoming>flow_startToClaim</bpmn:incoming>
+      <bpmn:outgoing>flow_claimToGateway</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="gateway_HasEmptySpots" name="Has empty&#10;spots?" default="Flow_no_spots">
-      <bpmn:incoming>Flow_claim_to_gateway</bpmn:incoming>
-      <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
-      <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_hasEmptySpots" name="Has empty&#10;spots?" default="flow_noSpots">
+      <bpmn:incoming>flow_claimToGateway</bpmn:incoming>
+      <bpmn:outgoing>flow_yesSpots</bpmn:outgoing>
+      <bpmn:outgoing>flow_noSpots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
-      <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
-      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
-        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+    <bpmn:subProcess id="subProcess_confirmMembership" name="Confirm Membership">
+      <bpmn:incoming>flow_yesSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_subProcessToWelcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_confirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>flow_subStartToConfirmationMail</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+      <bpmn:serviceTask id="serviceTask_sendConfirmationMail" name="Send&#10;Confirmation Mail">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
-        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+        <bpmn:incoming>flow_subStartToConfirmationMail</bpmn:incoming>
+        <bpmn:outgoing>flow_confirmationMailToUserTask</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+      <bpmn:userTask id="userTask_confirmMembership" name="Confirm Membership">
         <bpmn:extensionElements>
           <zeebe:userTask />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
-        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+        <bpmn:incoming>flow_confirmationMailToUserTask</bpmn:incoming>
+        <bpmn:outgoing>flow_userTaskToSubEnd</bpmn:outgoing>
       </bpmn:userTask>
-      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
-        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      <bpmn:endEvent id="endEvent_membershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>flow_userTaskToSubEnd</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
-      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
-      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+      <bpmn:sequenceFlow id="flow_subStartToConfirmationMail" sourceRef="startEvent_confirmationRequired" targetRef="serviceTask_sendConfirmationMail" />
+      <bpmn:sequenceFlow id="flow_confirmationMailToUserTask" sourceRef="serviceTask_sendConfirmationMail" targetRef="userTask_confirmMembership" />
+      <bpmn:sequenceFlow id="flow_userTaskToSubEnd" sourceRef="userTask_confirmMembership" targetRef="endEvent_membershipConfirmed" />
     </bpmn:subProcess>
-    <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
+    <bpmn:serviceTask id="serviceTask_sendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
+      <bpmn:incoming>flow_subProcessToWelcome</bpmn:incoming>
+      <bpmn:outgoing>flow_welcomeToActivated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
-      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>flow_welcomeToActivated</bpmn:incoming>
       <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
+    <bpmn:serviceTask id="serviceTask_sendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendRejectionMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_no_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_noSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_rejectionToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
-      <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipRejected" name="Membership&#10;rejected">
+      <bpmn:incoming>flow_rejectionToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_reminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timerToReSend</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+    <bpmn:serviceTask id="serviceTask_reSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
-      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_timerToReSend</bpmn:incoming>
+      <bpmn:outgoing>flow_reSendToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
-      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_mailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>flow_reSendToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_rejectedToRevoke</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timeoutToRevoke</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:exclusiveGateway id="gateway_RevokeReason">
-      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
-      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_gateway_to_revoke</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_revokeReason">
+      <bpmn:incoming>flow_timeoutToRevoke</bpmn:incoming>
+      <bpmn:incoming>flow_rejectedToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_gatewayToRevoke</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+    <bpmn:serviceTask id="serviceTask_revokeMembershipRequest" name="Revoke&#10;Membership Request">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_gateway_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+      <bpmn:incoming>flow_gatewayToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_revokeToDeclined</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
-      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>flow_revokeToDeclined</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+    <bpmn:serviceTask id="serviceTask_revokeClaim" name="Revoke Claim" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeClaim" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="event_ClaimCompensation" name="Claim made" attachedToRef="serviceTask_ClaimMembership">
+    <bpmn:boundaryEvent id="event_claimCompensation" name="Claim made" attachedToRef="serviceTask_claimMembership">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
-    <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
+    <bpmn:sequenceFlow id="flow_startToClaim" sourceRef="startEvent_membershipRequested" targetRef="serviceTask_claimMembership" />
+    <bpmn:sequenceFlow id="flow_claimToGateway" sourceRef="serviceTask_claimMembership" targetRef="gateway_hasEmptySpots" />
+    <bpmn:sequenceFlow id="flow_yesSpots" name="Yes" sourceRef="gateway_hasEmptySpots" targetRef="subProcess_confirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
-    <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
-    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
-    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
-    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_gateway_to_revoke" sourceRef="gateway_RevokeReason" targetRef="serviceTask_RevokeMembershipRequest" />
-    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
-    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
+    <bpmn:sequenceFlow id="flow_noSpots" name="No" sourceRef="gateway_hasEmptySpots" targetRef="serviceTask_sendRejectionMail" />
+    <bpmn:sequenceFlow id="flow_subProcessToWelcome" sourceRef="subProcess_confirmMembership" targetRef="serviceTask_sendWelcomeMail" />
+    <bpmn:sequenceFlow id="flow_welcomeToActivated" sourceRef="serviceTask_sendWelcomeMail" targetRef="endEvent_membershipActivated" />
+    <bpmn:sequenceFlow id="flow_rejectionToEnd" sourceRef="serviceTask_sendRejectionMail" targetRef="endEvent_membershipRejected" />
+    <bpmn:sequenceFlow id="flow_timerToReSend" sourceRef="event_reminderDue" targetRef="serviceTask_reSendConfirmationMail" />
+    <bpmn:sequenceFlow id="flow_reSendToEnd" sourceRef="serviceTask_reSendConfirmationMail" targetRef="endEvent_mailSentAgain" />
+    <bpmn:sequenceFlow id="flow_timeoutToRevoke" sourceRef="event_confirmationDeadlinePassed" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_rejectedToRevoke" sourceRef="event_confirmationRejected" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_gatewayToRevoke" sourceRef="gateway_revokeReason" targetRef="serviceTask_revokeMembershipRequest" />
+    <bpmn:sequenceFlow id="flow_revokeToDeclined" sourceRef="serviceTask_revokeMembershipRequest" targetRef="endEvent_membershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_claimCompensation" targetRef="serviceTask_revokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_membershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
+      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_claimMembership">
         <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_hasEmptySpots" isMarkerVisible="true">
         <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_confirmMembership" isExpanded="true">
         <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_confirmationRequired">
         <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="569" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_confirmMembership">
         <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_membershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="959" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+      <bpmndi:BPMNEdge id="flow_subStartToConfirmationMail_di" bpmnElement="flow_subStartToConfirmationMail">
         <di:waypoint x="618" y="333" />
         <di:waypoint x="670" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+      <bpmndi:BPMNEdge id="flow_confirmationMailToUserTask_di" bpmnElement="flow_confirmationMailToUserTask">
         <di:waypoint x="770" y="333" />
         <di:waypoint x="810" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+      <bpmndi:BPMNEdge id="flow_userTaskToSubEnd_di" bpmnElement="flow_userTaskToSubEnd">
         <di:waypoint x="910" y="333" />
         <di:waypoint x="972" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_sendWelcomeMail">
         <dc:Bounds x="1110" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_membershipActivated">
         <dc:Bounds x="1262" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
+      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_sendRejectionMail">
         <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
+      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_membershipRejected">
         <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="575" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_reSendConfirmationMail">
         <dc:Bounds x="1110" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_mailSentAgain">
         <dc:Bounds x="1262" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1252" y="575" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_RevokeReason" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_revokeReason" isMarkerVisible="true">
         <dc:Bounds x="1015" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_revokeMembershipRequest">
         <dc:Bounds x="1100" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_membershipDeclined">
         <dc:Bounds x="1262" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_revokeClaim">
         <dc:Bounds x="400" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_claimCompensation">
         <dc:Bounds x="312" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="250" y="244" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_confirmationDeadlinePassed">
         <dc:Bounds x="972" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="186" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_confirmationRejected">
         <dc:Bounds x="702" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="638" y="186" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_reminderDue">
         <dc:Bounds x="972" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
+      <bpmndi:BPMNEdge id="flow_startToClaim_di" bpmnElement="flow_startToClaim">
         <di:waypoint x="208" y="330" />
         <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
+      <bpmndi:BPMNEdge id="flow_claimToGateway_di" bpmnElement="flow_claimToGateway">
         <di:waypoint x="370" y="330" />
         <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
+      <bpmndi:BPMNEdge id="flow_yesSpots_di" bpmnElement="flow_yesSpots">
         <di:waypoint x="475" y="330" />
         <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
+      <bpmndi:BPMNEdge id="flow_noSpots_di" bpmnElement="flow_noSpots">
         <di:waypoint x="450" y="355" />
         <di:waypoint x="450" y="550" />
         <di:waypoint x="540" y="550" />
@@ -287,42 +287,42 @@
           <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+      <bpmndi:BPMNEdge id="flow_subProcessToWelcome_di" bpmnElement="flow_subProcessToWelcome">
         <di:waypoint x="1060" y="330" />
         <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+      <bpmndi:BPMNEdge id="flow_welcomeToActivated_di" bpmnElement="flow_welcomeToActivated">
         <di:waypoint x="1210" y="330" />
         <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
+      <bpmndi:BPMNEdge id="flow_rejectionToEnd_di" bpmnElement="flow_rejectionToEnd">
         <di:waypoint x="640" y="550" />
         <di:waypoint x="702" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+      <bpmndi:BPMNEdge id="flow_timerToReSend_di" bpmnElement="flow_timerToReSend">
         <di:waypoint x="990" y="458" />
         <di:waypoint x="990" y="550" />
         <di:waypoint x="1110" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+      <bpmndi:BPMNEdge id="flow_reSendToEnd_di" bpmnElement="flow_reSendToEnd">
         <di:waypoint x="1210" y="550" />
         <di:waypoint x="1262" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+      <bpmndi:BPMNEdge id="flow_timeoutToRevoke_di" bpmnElement="flow_timeoutToRevoke">
         <di:waypoint x="990" y="212" />
         <di:waypoint x="990" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+      <bpmndi:BPMNEdge id="flow_rejectedToRevoke_di" bpmnElement="flow_rejectedToRevoke">
         <di:waypoint x="720" y="212" />
         <di:waypoint x="720" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_gateway_to_revoke_di" bpmnElement="Flow_gateway_to_revoke">
+      <bpmndi:BPMNEdge id="flow_gatewayToRevoke_di" bpmnElement="flow_gatewayToRevoke">
         <di:waypoint x="1065" y="120" />
         <di:waypoint x="1100" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+      <bpmndi:BPMNEdge id="flow_revokeToDeclined_di" bpmnElement="flow_revokeToDeclined">
         <di:waypoint x="1200" y="120" />
         <di:waypoint x="1262" y="120" />
       </bpmndi:BPMNEdge>

--- a/docs/bpmn-quality-gates/probes/probe-messy/README.md
+++ b/docs/bpmn-quality-gates/probes/probe-messy/README.md
@@ -22,8 +22,8 @@ $ npx bpmnlint probe-messy.bpmn
 With `local/flow-through-element` (error) in place, both penetrated elements are reported:
 
 ```
-  Flow_no_spots  error  Sequence flow is routed through element <serviceTask_SendConfirmationMail>  local/flow-through-element
-  Flow_no_spots  error  Sequence flow is routed through element <endEvent_MembershipRejected>       local/flow-through-element
+  flow_noSpots  error  Sequence flow is routed through element <serviceTask_sendConfirmationMail>  local/flow-through-element
+  flow_noSpots  error  Sequence flow is routed through element <endEvent_membershipRejected>       local/flow-through-element
 ✖ 2 problems (2 errors, 0 warnings)                # exit 1
 ```
 

--- a/docs/bpmn-quality-gates/probes/probe-messy/probe-messy.bpmn
+++ b/docs/bpmn-quality-gates/probes/probe-messy/probe-messy.bpmn
@@ -12,277 +12,277 @@
   </bpmn:message>
   <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
+    <bpmn:startEvent id="startEvent_membershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:outgoing>flow_startToClaim</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
-    <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
+    <bpmn:serviceTask id="serviceTask_claimMembership" name="Claim Membership">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.claimMembership" />
         <zeebe:ioMapping>
           <zeebe:output source="=hasEmptySpots" target="hasEmptySpots" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_start_to_claim</bpmn:incoming>
-      <bpmn:outgoing>Flow_claim_to_gateway</bpmn:outgoing>
+      <bpmn:incoming>flow_startToClaim</bpmn:incoming>
+      <bpmn:outgoing>flow_claimToGateway</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="gateway_HasEmptySpots" name="Has empty&#10;spots?" default="Flow_no_spots">
-      <bpmn:incoming>Flow_claim_to_gateway</bpmn:incoming>
-      <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
-      <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_hasEmptySpots" name="Has empty&#10;spots?" default="flow_noSpots">
+      <bpmn:incoming>flow_claimToGateway</bpmn:incoming>
+      <bpmn:outgoing>flow_yesSpots</bpmn:outgoing>
+      <bpmn:outgoing>flow_noSpots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
-      <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
-      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
-        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+    <bpmn:subProcess id="subProcess_confirmMembership" name="Confirm Membership">
+      <bpmn:incoming>flow_yesSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_subProcessToWelcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_confirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>flow_subStartToConfirmationMail</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+      <bpmn:serviceTask id="serviceTask_sendConfirmationMail" name="Send&#10;Confirmation Mail">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
-        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+        <bpmn:incoming>flow_subStartToConfirmationMail</bpmn:incoming>
+        <bpmn:outgoing>flow_confirmationMailToUserTask</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+      <bpmn:userTask id="userTask_confirmMembership" name="Confirm Membership">
         <bpmn:extensionElements>
           <zeebe:userTask />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
-        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+        <bpmn:incoming>flow_confirmationMailToUserTask</bpmn:incoming>
+        <bpmn:outgoing>flow_userTaskToSubEnd</bpmn:outgoing>
       </bpmn:userTask>
-      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
-        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      <bpmn:endEvent id="endEvent_membershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>flow_userTaskToSubEnd</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
-      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
-      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+      <bpmn:sequenceFlow id="flow_subStartToConfirmationMail" sourceRef="startEvent_confirmationRequired" targetRef="serviceTask_sendConfirmationMail" />
+      <bpmn:sequenceFlow id="flow_confirmationMailToUserTask" sourceRef="serviceTask_sendConfirmationMail" targetRef="userTask_confirmMembership" />
+      <bpmn:sequenceFlow id="flow_userTaskToSubEnd" sourceRef="userTask_confirmMembership" targetRef="endEvent_membershipConfirmed" />
     </bpmn:subProcess>
-    <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
+    <bpmn:serviceTask id="serviceTask_sendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
+      <bpmn:incoming>flow_subProcessToWelcome</bpmn:incoming>
+      <bpmn:outgoing>flow_welcomeToActivated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
-      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>flow_welcomeToActivated</bpmn:incoming>
       <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
+    <bpmn:serviceTask id="serviceTask_sendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendRejectionMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_no_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_noSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_rejectionToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
-      <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipRejected" name="Membership&#10;rejected">
+      <bpmn:incoming>flow_rejectionToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_reminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timerToReSend</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+    <bpmn:serviceTask id="serviceTask_reSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
-      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_timerToReSend</bpmn:incoming>
+      <bpmn:outgoing>flow_reSendToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
-      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_mailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>flow_reSendToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_rejectedToRevoke</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timeoutToRevoke</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:exclusiveGateway id="gateway_RevokeReason">
-      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
-      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_gateway_to_revoke</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_revokeReason">
+      <bpmn:incoming>flow_timeoutToRevoke</bpmn:incoming>
+      <bpmn:incoming>flow_rejectedToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_gatewayToRevoke</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+    <bpmn:serviceTask id="serviceTask_revokeMembershipRequest" name="Revoke&#10;Membership Request">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_gateway_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+      <bpmn:incoming>flow_gatewayToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_revokeToDeclined</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
-      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>flow_revokeToDeclined</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+    <bpmn:serviceTask id="serviceTask_revokeClaim" name="Revoke Claim" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeClaim" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="event_ClaimCompensation" name="Claim made" attachedToRef="serviceTask_ClaimMembership">
+    <bpmn:boundaryEvent id="event_claimCompensation" name="Claim made" attachedToRef="serviceTask_claimMembership">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
-    <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
+    <bpmn:sequenceFlow id="flow_startToClaim" sourceRef="startEvent_membershipRequested" targetRef="serviceTask_claimMembership" />
+    <bpmn:sequenceFlow id="flow_claimToGateway" sourceRef="serviceTask_claimMembership" targetRef="gateway_hasEmptySpots" />
+    <bpmn:sequenceFlow id="flow_yesSpots" name="Yes" sourceRef="gateway_hasEmptySpots" targetRef="subProcess_confirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
-    <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
-    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
-    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
-    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_gateway_to_revoke" sourceRef="gateway_RevokeReason" targetRef="serviceTask_RevokeMembershipRequest" />
-    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
-    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
+    <bpmn:sequenceFlow id="flow_noSpots" name="No" sourceRef="gateway_hasEmptySpots" targetRef="serviceTask_sendRejectionMail" />
+    <bpmn:sequenceFlow id="flow_subProcessToWelcome" sourceRef="subProcess_confirmMembership" targetRef="serviceTask_sendWelcomeMail" />
+    <bpmn:sequenceFlow id="flow_welcomeToActivated" sourceRef="serviceTask_sendWelcomeMail" targetRef="endEvent_membershipActivated" />
+    <bpmn:sequenceFlow id="flow_rejectionToEnd" sourceRef="serviceTask_sendRejectionMail" targetRef="endEvent_membershipRejected" />
+    <bpmn:sequenceFlow id="flow_timerToReSend" sourceRef="event_reminderDue" targetRef="serviceTask_reSendConfirmationMail" />
+    <bpmn:sequenceFlow id="flow_reSendToEnd" sourceRef="serviceTask_reSendConfirmationMail" targetRef="endEvent_mailSentAgain" />
+    <bpmn:sequenceFlow id="flow_timeoutToRevoke" sourceRef="event_confirmationDeadlinePassed" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_rejectedToRevoke" sourceRef="event_confirmationRejected" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_gatewayToRevoke" sourceRef="gateway_revokeReason" targetRef="serviceTask_revokeMembershipRequest" />
+    <bpmn:sequenceFlow id="flow_revokeToDeclined" sourceRef="serviceTask_revokeMembershipRequest" targetRef="endEvent_membershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_claimCompensation" targetRef="serviceTask_revokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_membershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
+      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_claimMembership">
         <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_hasEmptySpots" isMarkerVisible="true">
         <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_confirmMembership" isExpanded="true">
         <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_confirmationRequired">
         <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="569" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_sendConfirmationMail">
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_confirmMembership">
         <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_membershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="959" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+      <bpmndi:BPMNEdge id="flow_subStartToConfirmationMail_di" bpmnElement="flow_subStartToConfirmationMail">
         <di:waypoint x="618" y="333" />
         <di:waypoint x="670" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+      <bpmndi:BPMNEdge id="flow_confirmationMailToUserTask_di" bpmnElement="flow_confirmationMailToUserTask">
         <di:waypoint x="770" y="333" />
         <di:waypoint x="810" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+      <bpmndi:BPMNEdge id="flow_userTaskToSubEnd_di" bpmnElement="flow_userTaskToSubEnd">
         <di:waypoint x="910" y="333" />
         <di:waypoint x="972" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_sendWelcomeMail">
         <dc:Bounds x="1110" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_membershipActivated">
         <dc:Bounds x="1262" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
+      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_sendRejectionMail">
         <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
+      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_membershipRejected">
         <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="575" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_reSendConfirmationMail">
         <dc:Bounds x="1110" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_mailSentAgain">
         <dc:Bounds x="1262" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1252" y="575" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_RevokeReason" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_revokeReason" isMarkerVisible="true">
         <dc:Bounds x="1015" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_revokeMembershipRequest">
         <dc:Bounds x="1100" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_membershipDeclined">
         <dc:Bounds x="1262" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_revokeClaim">
         <dc:Bounds x="400" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_claimCompensation">
         <dc:Bounds x="312" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="250" y="244" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_confirmationDeadlinePassed">
         <dc:Bounds x="972" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="186" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_confirmationRejected">
         <dc:Bounds x="702" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="638" y="186" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_reminderDue">
         <dc:Bounds x="972" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
+      <bpmndi:BPMNEdge id="flow_startToClaim_di" bpmnElement="flow_startToClaim">
         <di:waypoint x="208" y="330" />
         <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
+      <bpmndi:BPMNEdge id="flow_claimToGateway_di" bpmnElement="flow_claimToGateway">
         <di:waypoint x="370" y="330" />
         <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
+      <bpmndi:BPMNEdge id="flow_yesSpots_di" bpmnElement="flow_yesSpots">
         <di:waypoint x="475" y="330" />
         <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
+      <bpmndi:BPMNEdge id="flow_noSpots_di" bpmnElement="flow_noSpots">
         <di:waypoint x="450" y="355" />
         <di:waypoint x="800" y="355" />
         <di:waypoint x="800" y="550" />
@@ -291,42 +291,42 @@
           <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+      <bpmndi:BPMNEdge id="flow_subProcessToWelcome_di" bpmnElement="flow_subProcessToWelcome">
         <di:waypoint x="1060" y="330" />
         <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+      <bpmndi:BPMNEdge id="flow_welcomeToActivated_di" bpmnElement="flow_welcomeToActivated">
         <di:waypoint x="1210" y="330" />
         <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
+      <bpmndi:BPMNEdge id="flow_rejectionToEnd_di" bpmnElement="flow_rejectionToEnd">
         <di:waypoint x="640" y="550" />
         <di:waypoint x="702" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+      <bpmndi:BPMNEdge id="flow_timerToReSend_di" bpmnElement="flow_timerToReSend">
         <di:waypoint x="990" y="458" />
         <di:waypoint x="990" y="550" />
         <di:waypoint x="1110" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+      <bpmndi:BPMNEdge id="flow_reSendToEnd_di" bpmnElement="flow_reSendToEnd">
         <di:waypoint x="1210" y="550" />
         <di:waypoint x="1262" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+      <bpmndi:BPMNEdge id="flow_timeoutToRevoke_di" bpmnElement="flow_timeoutToRevoke">
         <di:waypoint x="990" y="212" />
         <di:waypoint x="990" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+      <bpmndi:BPMNEdge id="flow_rejectedToRevoke_di" bpmnElement="flow_rejectedToRevoke">
         <di:waypoint x="720" y="212" />
         <di:waypoint x="720" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_gateway_to_revoke_di" bpmnElement="Flow_gateway_to_revoke">
+      <bpmndi:BPMNEdge id="flow_gatewayToRevoke_di" bpmnElement="flow_gatewayToRevoke">
         <di:waypoint x="1065" y="120" />
         <di:waypoint x="1100" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+      <bpmndi:BPMNEdge id="flow_revokeToDeclined_di" bpmnElement="flow_revokeToDeclined">
         <di:waypoint x="1200" y="120" />
         <di:waypoint x="1262" y="120" />
       </bpmndi:BPMNEdge>

--- a/docs/bpmn-styleguide/styleguide.md
+++ b/docs/bpmn-styleguide/styleguide.md
@@ -113,21 +113,45 @@ Clear conventions for IDs, message names, and type IDs help maintain an overview
 ### Element IDs
 
 Unique, readable IDs make BPMN diagrams easier to maintain and analyse.
-Every element relevant to automation should have an ID following the format `Type_Name`,
-where both `Type` and `Name` are written in CamelCase.
+Every element relevant to automation should have an ID following the format `type_name`, where both
+`type` and `name` are written in **lowerCamelCase** — so the whole ID reads as one camelCase token with
+an underscore separating the type from the name (e.g. `serviceTask_sendWelcomeMail`, `flow_noSpots`).
 
-The table below is illustrative — it shows the pattern for common element types, not an exhaustive list.
-Apply the same `Type_Name` structure to any element not listed here.
+The table below covers every **executable** element type — all event, task and gateway kinds,
+sub-processes, call activities and sequence flows — and the linter (`local/element-id`) enforces it.
+Non-executable elements Zeebe ignores (text annotations, groups, associations, data objects/stores,
+pools/lanes) are not checked; their ids are auto-generated and carry no automation meaning. Apply the
+same `type_name` structure to any element not listed here.
 
-| Element              | ID Convention             | Example                          |
-| -------------------- | ------------------------- | -------------------------------- |
-| Start Event          | `startEvent_State`        | `startEvent_SubscriptionStarted` |
-| Intermediate Event   | `event_State`             | `event_ConfirmationReceived`     |
-| End Event            | `endEvent_State`          | `endEvent_SubscriptionCompleted` |
-| Service Task         | `serviceTask_Description` | `serviceTask_SendWelcomeMail`    |
-| User Task            | `userTask_Description`    | `userTask_ReviewSubscription`    |
-| Message Receive Task | `receiveTask_Description` | `receiveTask_AwaitConfirmation`  |
-| Gateway              | `gateway_Description`     | `gateway_IsCustomerKnown`        |
+| Element                          | ID Convention                                            | Example                          |
+| -------------------------------- | -------------------------------------------------------- | -------------------------------- |
+| Start Event                      | `startEvent_state`                                       | `startEvent_subscriptionStarted` |
+| Intermediate Event (catch/throw) | `event_state`                                            | `event_confirmationReceived`     |
+| End Event                        | `endEvent_state`                                         | `endEvent_subscriptionCompleted` |
+| Boundary Event                   | `boundary_state` or `event_state`                        | `boundary_reminderDue`           |
+| Task (undefined type)            | `task_description`                                       | `task_archiveRecord`             |
+| Service Task                     | `serviceTask_description`                                | `serviceTask_sendWelcomeMail`    |
+| User Task                        | `userTask_description`                                   | `userTask_reviewSubscription`    |
+| Send Task                        | `sendTask_description`                                   | `sendTask_notifyCustomer`        |
+| Message Receive Task             | `receiveTask_description`                                | `receiveTask_awaitConfirmation`  |
+| Manual Task                      | `manualTask_description`                                 | `manualTask_fileDocument`        |
+| Script Task                      | `scriptTask_description`                                 | `scriptTask_calculateScore`      |
+| Business Rule Task               | `businessRuleTask_description`                           | `businessRuleTask_checkCredit`   |
+| Gateway (all kinds)              | `gateway_description`                                    | `gateway_isCustomerKnown`        |
+| Sub-Process                      | `subProcess_description`                                 | `subProcess_confirmMembership`   |
+| Transaction                      | `transaction_description` or `subProcess_description`    | `transaction_reserveSeats`       |
+| Ad-Hoc Sub-Process               | `adHocSubProcess_description` or `subProcess_description`| `adHocSubProcess_triageTickets`  |
+| Call Activity                    | `callActivity_description`                               | `callActivity_shipOrder`         |
+| Sequence Flow                    | `flow_description`                                       | `flow_claimToGateway`            |
+
+Where two forms are shown, both are accepted — a sensible specific prefix (`boundary_`,
+`transaction_`, `adHocSubProcess_`) **or** the normal generic one (`event_`, `subProcess_`). All
+gateway kinds share the flat `gateway_` prefix.
+
+Events may additionally qualify the prefix with their event definition — `messageStartEvent_state`,
+`timerStartEvent_state`, `messageBoundary_state`, and so on. This qualifier is optional, but if present
+it must be truthful: a `timerStartEvent_` prefix on a message start event is wrong, because an ID that
+lies about the model is worse than one that stays silent about it.
 
 ### Message IDs
 
@@ -149,7 +173,7 @@ subscribes to. To ensure uniqueness across services, use the following schema �
 <serviceName>.<elementIdWithoutTypePrefix>
 ```
 
-> Example: if the service task ID is `serviceTask_SendWelcomeMail` in the `miravelo` service, the
+> Example: if the service task ID is `serviceTask_sendWelcomeMail` in the `miravelo` service, the
 > type ID is `miravelo.sendWelcomeMail`.
 
 ---

--- a/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
+++ b/services/example-service/src/main/kotlin/io/miragon/example/adapter/process/MiraveloMembershipProcessApi.kt
@@ -26,56 +26,56 @@ object MiraveloMembershipProcessApi {
    * Worker runtime code rarely needs these.
    */
   object Elements {
-    val END_EVENT_MAIL_SENT_AGAIN: ElementId = ElementId("endEvent_MailSentAgain")
+    val END_EVENT_MAIL_SENT_AGAIN: ElementId = ElementId("endEvent_mailSentAgain")
 
-    val END_EVENT_MEMBERSHIP_ACTIVATED: ElementId = ElementId("endEvent_MembershipActivated")
+    val END_EVENT_MEMBERSHIP_ACTIVATED: ElementId = ElementId("endEvent_membershipActivated")
 
-    val END_EVENT_MEMBERSHIP_CONFIRMED: ElementId = ElementId("endEvent_MembershipConfirmed")
+    val END_EVENT_MEMBERSHIP_CONFIRMED: ElementId = ElementId("endEvent_membershipConfirmed")
 
-    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_MembershipDeclined")
+    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_membershipDeclined")
 
-    val END_EVENT_MEMBERSHIP_REJECTED: ElementId = ElementId("endEvent_MembershipRejected")
+    val END_EVENT_MEMBERSHIP_REJECTED: ElementId = ElementId("endEvent_membershipRejected")
 
-    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_ClaimCompensation")
+    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_claimCompensation")
 
     val EVENT_CONFIRMATION_DEADLINE_PASSED: ElementId =
-        ElementId("event_ConfirmationDeadlinePassed")
+        ElementId("event_confirmationDeadlinePassed")
 
-    val EVENT_CONFIRMATION_REJECTED: ElementId = ElementId("event_ConfirmationRejected")
+    val EVENT_CONFIRMATION_REJECTED: ElementId = ElementId("event_confirmationRejected")
 
-    val EVENT_REMINDER_DUE: ElementId = ElementId("event_ReminderDue")
+    val EVENT_REMINDER_DUE: ElementId = ElementId("event_reminderDue")
 
-    val GATEWAY_HAS_EMPTY_SPOTS: ElementId = ElementId("gateway_HasEmptySpots")
+    val GATEWAY_HAS_EMPTY_SPOTS: ElementId = ElementId("gateway_hasEmptySpots")
 
-    val GATEWAY_REVOKE_REASON: ElementId = ElementId("gateway_RevokeReason")
+    val GATEWAY_REVOKE_REASON: ElementId = ElementId("gateway_revokeReason")
 
-    val SERVICE_TASK_CLAIM_MEMBERSHIP: ElementId = ElementId("serviceTask_ClaimMembership")
+    val SERVICE_TASK_CLAIM_MEMBERSHIP: ElementId = ElementId("serviceTask_claimMembership")
 
     val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: ElementId =
-        ElementId("serviceTask_ReSendConfirmationMail")
+        ElementId("serviceTask_reSendConfirmationMail")
 
-    val SERVICE_TASK_REVOKE_CLAIM: ElementId = ElementId("serviceTask_RevokeClaim")
+    val SERVICE_TASK_REVOKE_CLAIM: ElementId = ElementId("serviceTask_revokeClaim")
 
     val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: ElementId =
-        ElementId("serviceTask_RevokeMembershipRequest")
+        ElementId("serviceTask_revokeMembershipRequest")
 
     val SERVICE_TASK_SEND_CONFIRMATION_MAIL: ElementId =
-        ElementId("serviceTask_SendConfirmationMail")
+        ElementId("serviceTask_sendConfirmationMail")
 
     val SERVICE_TASK_SEND_REJECTION_MAIL: ElementId =
-        ElementId("serviceTask_SendRejectionMail")
+        ElementId("serviceTask_sendRejectionMail")
 
-    val SERVICE_TASK_SEND_WELCOME_MAIL: ElementId = ElementId("serviceTask_SendWelcomeMail")
+    val SERVICE_TASK_SEND_WELCOME_MAIL: ElementId = ElementId("serviceTask_sendWelcomeMail")
 
     val START_EVENT_CONFIRMATION_REQUIRED: ElementId =
-        ElementId("startEvent_ConfirmationRequired")
+        ElementId("startEvent_confirmationRequired")
 
     val START_EVENT_MEMBERSHIP_REQUESTED: ElementId =
-        ElementId("startEvent_MembershipRequested")
+        ElementId("startEvent_membershipRequested")
 
-    val SUB_PROCESS_CONFIRM_MEMBERSHIP: ElementId = ElementId("subProcess_ConfirmMembership")
+    val SUB_PROCESS_CONFIRM_MEMBERSHIP: ElementId = ElementId("subProcess_confirmMembership")
 
-    val USER_TASK_CONFIRM_MEMBERSHIP: ElementId = ElementId("userTask_ConfirmMembership")
+    val USER_TASK_CONFIRM_MEMBERSHIP: ElementId = ElementId("userTask_confirmMembership")
   }
 
   /**
@@ -116,9 +116,9 @@ object MiraveloMembershipProcessApi {
   }
 
   object Compensations {
-    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_MembershipDeclined")
+    val END_EVENT_MEMBERSHIP_DECLINED: ElementId = ElementId("endEvent_membershipDeclined")
 
-    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_ClaimCompensation")
+    val EVENT_CLAIM_COMPENSATION: ElementId = ElementId("event_claimCompensation")
   }
 
   object Signals {
@@ -148,102 +148,102 @@ object MiraveloMembershipProcessApi {
    */
   object Flows {
     val FLOW_CLAIM_TO_GATEWAY: BpmnFlow = BpmnFlow(
-          id = "Flow_claim_to_gateway",
-          sourceRef = "serviceTask_ClaimMembership",
-          targetRef = "gateway_HasEmptySpots",
+          id = "flow_claimToGateway",
+          sourceRef = "serviceTask_claimMembership",
+          targetRef = "gateway_hasEmptySpots",
         )
 
     val FLOW_CONFIRMATION_MAIL_TO_USER_TASK: BpmnFlow = BpmnFlow(
-          id = "Flow_confirmationMail_to_userTask",
-          sourceRef = "serviceTask_SendConfirmationMail",
-          targetRef = "userTask_ConfirmMembership",
+          id = "flow_confirmationMailToUserTask",
+          sourceRef = "serviceTask_sendConfirmationMail",
+          targetRef = "userTask_confirmMembership",
         )
 
     val FLOW_GATEWAY_TO_REVOKE: BpmnFlow = BpmnFlow(
-          id = "Flow_gateway_to_revoke",
-          sourceRef = "gateway_RevokeReason",
-          targetRef = "serviceTask_RevokeMembershipRequest",
+          id = "flow_gatewayToRevoke",
+          sourceRef = "gateway_revokeReason",
+          targetRef = "serviceTask_revokeMembershipRequest",
         )
 
     val FLOW_NO_SPOTS: BpmnFlow = BpmnFlow(
-          id = "Flow_no_spots",
+          id = "flow_noSpots",
           name = "No",
-          sourceRef = "gateway_HasEmptySpots",
-          targetRef = "serviceTask_SendRejectionMail",
+          sourceRef = "gateway_hasEmptySpots",
+          targetRef = "serviceTask_sendRejectionMail",
           isDefault = true,
         )
 
     val FLOW_RE_SEND_TO_END: BpmnFlow = BpmnFlow(
-          id = "Flow_reSend_to_end",
-          sourceRef = "serviceTask_ReSendConfirmationMail",
-          targetRef = "endEvent_MailSentAgain",
+          id = "flow_reSendToEnd",
+          sourceRef = "serviceTask_reSendConfirmationMail",
+          targetRef = "endEvent_mailSentAgain",
         )
 
     val FLOW_REJECTED_TO_REVOKE: BpmnFlow = BpmnFlow(
-          id = "Flow_rejected_to_revoke",
-          sourceRef = "event_ConfirmationRejected",
-          targetRef = "gateway_RevokeReason",
+          id = "flow_rejectedToRevoke",
+          sourceRef = "event_confirmationRejected",
+          targetRef = "gateway_revokeReason",
         )
 
     val FLOW_REJECTION_TO_END: BpmnFlow = BpmnFlow(
-          id = "Flow_rejection_to_end",
-          sourceRef = "serviceTask_SendRejectionMail",
-          targetRef = "endEvent_MembershipRejected",
+          id = "flow_rejectionToEnd",
+          sourceRef = "serviceTask_sendRejectionMail",
+          targetRef = "endEvent_membershipRejected",
         )
 
     val FLOW_REVOKE_TO_DECLINED: BpmnFlow = BpmnFlow(
-          id = "Flow_revoke_to_declined",
-          sourceRef = "serviceTask_RevokeMembershipRequest",
-          targetRef = "endEvent_MembershipDeclined",
+          id = "flow_revokeToDeclined",
+          sourceRef = "serviceTask_revokeMembershipRequest",
+          targetRef = "endEvent_membershipDeclined",
         )
 
     val FLOW_START_TO_CLAIM: BpmnFlow = BpmnFlow(
-          id = "Flow_start_to_claim",
-          sourceRef = "startEvent_MembershipRequested",
-          targetRef = "serviceTask_ClaimMembership",
+          id = "flow_startToClaim",
+          sourceRef = "startEvent_membershipRequested",
+          targetRef = "serviceTask_claimMembership",
         )
 
     val FLOW_SUB_PROCESS_TO_WELCOME: BpmnFlow = BpmnFlow(
-          id = "Flow_subProcess_to_welcome",
-          sourceRef = "subProcess_ConfirmMembership",
-          targetRef = "serviceTask_SendWelcomeMail",
+          id = "flow_subProcessToWelcome",
+          sourceRef = "subProcess_confirmMembership",
+          targetRef = "serviceTask_sendWelcomeMail",
         )
 
     val FLOW_SUB_START_TO_CONFIRMATION_MAIL: BpmnFlow = BpmnFlow(
-          id = "Flow_subStart_to_confirmationMail",
-          sourceRef = "startEvent_ConfirmationRequired",
-          targetRef = "serviceTask_SendConfirmationMail",
+          id = "flow_subStartToConfirmationMail",
+          sourceRef = "startEvent_confirmationRequired",
+          targetRef = "serviceTask_sendConfirmationMail",
         )
 
     val FLOW_TIMEOUT_TO_REVOKE: BpmnFlow = BpmnFlow(
-          id = "Flow_timeout_to_revoke",
-          sourceRef = "event_ConfirmationDeadlinePassed",
-          targetRef = "gateway_RevokeReason",
+          id = "flow_timeoutToRevoke",
+          sourceRef = "event_confirmationDeadlinePassed",
+          targetRef = "gateway_revokeReason",
         )
 
     val FLOW_TIMER_TO_RE_SEND: BpmnFlow = BpmnFlow(
-          id = "Flow_timer_to_reSend",
-          sourceRef = "event_ReminderDue",
-          targetRef = "serviceTask_ReSendConfirmationMail",
+          id = "flow_timerToReSend",
+          sourceRef = "event_reminderDue",
+          targetRef = "serviceTask_reSendConfirmationMail",
         )
 
     val FLOW_USER_TASK_TO_SUB_END: BpmnFlow = BpmnFlow(
-          id = "Flow_userTask_to_subEnd",
-          sourceRef = "userTask_ConfirmMembership",
-          targetRef = "endEvent_MembershipConfirmed",
+          id = "flow_userTaskToSubEnd",
+          sourceRef = "userTask_confirmMembership",
+          targetRef = "endEvent_membershipConfirmed",
         )
 
     val FLOW_WELCOME_TO_ACTIVATED: BpmnFlow = BpmnFlow(
-          id = "Flow_welcome_to_activated",
-          sourceRef = "serviceTask_SendWelcomeMail",
-          targetRef = "endEvent_MembershipActivated",
+          id = "flow_welcomeToActivated",
+          sourceRef = "serviceTask_sendWelcomeMail",
+          targetRef = "endEvent_membershipActivated",
         )
 
     val FLOW_YES_SPOTS: BpmnFlow = BpmnFlow(
-          id = "Flow_yes_spots",
+          id = "flow_yesSpots",
           name = "Yes",
-          sourceRef = "gateway_HasEmptySpots",
-          targetRef = "subProcess_ConfirmMembership",
+          sourceRef = "gateway_hasEmptySpots",
+          targetRef = "subProcess_confirmMembership",
           condition = "=hasEmptySpots",
         )
   }
@@ -255,7 +255,7 @@ object MiraveloMembershipProcessApi {
   object Relations {
     val END_EVENT_MAIL_SENT_AGAIN: BpmnRelations = BpmnRelations(
           name = "Mail sent again",
-          previousElements = listOf("serviceTask_ReSendConfirmationMail"),
+          previousElements = listOf("serviceTask_reSendConfirmationMail"),
           followingElements = emptyList(),
           parentId = null,
           attachedToRef = null,
@@ -264,7 +264,7 @@ object MiraveloMembershipProcessApi {
 
     val END_EVENT_MEMBERSHIP_ACTIVATED: BpmnRelations = BpmnRelations(
           name = "Membership activated",
-          previousElements = listOf("serviceTask_SendWelcomeMail"),
+          previousElements = listOf("serviceTask_sendWelcomeMail"),
           followingElements = emptyList(),
           parentId = null,
           attachedToRef = null,
@@ -273,16 +273,16 @@ object MiraveloMembershipProcessApi {
 
     val END_EVENT_MEMBERSHIP_CONFIRMED: BpmnRelations = BpmnRelations(
           name = "Membership confirmed",
-          previousElements = listOf("userTask_ConfirmMembership"),
+          previousElements = listOf("userTask_confirmMembership"),
           followingElements = emptyList(),
-          parentId = "subProcess_ConfirmMembership",
+          parentId = "subProcess_confirmMembership",
           attachedToRef = null,
           attachedElements = emptyList(),
         )
 
     val END_EVENT_MEMBERSHIP_DECLINED: BpmnRelations = BpmnRelations(
           name = "Membership declined",
-          previousElements = listOf("serviceTask_RevokeMembershipRequest"),
+          previousElements = listOf("serviceTask_revokeMembershipRequest"),
           followingElements = emptyList(),
           parentId = null,
           attachedToRef = null,
@@ -291,7 +291,7 @@ object MiraveloMembershipProcessApi {
 
     val END_EVENT_MEMBERSHIP_REJECTED: BpmnRelations = BpmnRelations(
           name = "Membership rejected",
-          previousElements = listOf("serviceTask_SendRejectionMail"),
+          previousElements = listOf("serviceTask_sendRejectionMail"),
           followingElements = emptyList(),
           parentId = null,
           attachedToRef = null,
@@ -303,49 +303,49 @@ object MiraveloMembershipProcessApi {
           previousElements = emptyList(),
           followingElements = emptyList(),
           parentId = null,
-          attachedToRef = "serviceTask_ClaimMembership",
+          attachedToRef = "serviceTask_claimMembership",
           attachedElements = emptyList(),
         )
 
     val EVENT_CONFIRMATION_DEADLINE_PASSED: BpmnRelations = BpmnRelations(
           name = "Deadline passed",
           previousElements = emptyList(),
-          followingElements = listOf("gateway_RevokeReason"),
+          followingElements = listOf("gateway_revokeReason"),
           parentId = null,
-          attachedToRef = "subProcess_ConfirmMembership",
+          attachedToRef = "subProcess_confirmMembership",
           attachedElements = emptyList(),
         )
 
     val EVENT_CONFIRMATION_REJECTED: BpmnRelations = BpmnRelations(
           name = "Confirmation rejected",
           previousElements = emptyList(),
-          followingElements = listOf("gateway_RevokeReason"),
+          followingElements = listOf("gateway_revokeReason"),
           parentId = null,
-          attachedToRef = "subProcess_ConfirmMembership",
+          attachedToRef = "subProcess_confirmMembership",
           attachedElements = emptyList(),
         )
 
     val EVENT_REMINDER_DUE: BpmnRelations = BpmnRelations(
           name = "Reminder due",
           previousElements = emptyList(),
-          followingElements = listOf("serviceTask_ReSendConfirmationMail"),
+          followingElements = listOf("serviceTask_reSendConfirmationMail"),
           parentId = null,
-          attachedToRef = "subProcess_ConfirmMembership",
+          attachedToRef = "subProcess_confirmMembership",
           attachedElements = emptyList(),
         )
 
     val GATEWAY_HAS_EMPTY_SPOTS: BpmnRelations = BpmnRelations(
           name = "Has empty spots?",
-          previousElements = listOf("serviceTask_ClaimMembership"),
-          followingElements = listOf("subProcess_ConfirmMembership", "serviceTask_SendRejectionMail"),
+          previousElements = listOf("serviceTask_claimMembership"),
+          followingElements = listOf("subProcess_confirmMembership", "serviceTask_sendRejectionMail"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
         )
 
     val GATEWAY_REVOKE_REASON: BpmnRelations = BpmnRelations(
-          previousElements = listOf("event_ConfirmationDeadlinePassed", "event_ConfirmationRejected"),
-          followingElements = listOf("serviceTask_RevokeMembershipRequest"),
+          previousElements = listOf("event_confirmationDeadlinePassed", "event_confirmationRejected"),
+          followingElements = listOf("serviceTask_revokeMembershipRequest"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -353,17 +353,17 @@ object MiraveloMembershipProcessApi {
 
     val SERVICE_TASK_CLAIM_MEMBERSHIP: BpmnRelations = BpmnRelations(
           name = "Claim Membership",
-          previousElements = listOf("startEvent_MembershipRequested"),
-          followingElements = listOf("gateway_HasEmptySpots"),
+          previousElements = listOf("startEvent_membershipRequested"),
+          followingElements = listOf("gateway_hasEmptySpots"),
           parentId = null,
           attachedToRef = null,
-          attachedElements = listOf("event_ClaimCompensation"),
+          attachedElements = listOf("event_claimCompensation"),
         )
 
     val SERVICE_TASK_RE_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
           name = "Re-Send Confirmation Mail",
-          previousElements = listOf("event_ReminderDue"),
-          followingElements = listOf("endEvent_MailSentAgain"),
+          previousElements = listOf("event_reminderDue"),
+          followingElements = listOf("endEvent_mailSentAgain"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -380,8 +380,8 @@ object MiraveloMembershipProcessApi {
 
     val SERVICE_TASK_REVOKE_MEMBERSHIP_REQUEST: BpmnRelations = BpmnRelations(
           name = "Revoke Membership Request",
-          previousElements = listOf("gateway_RevokeReason"),
-          followingElements = listOf("endEvent_MembershipDeclined"),
+          previousElements = listOf("gateway_revokeReason"),
+          followingElements = listOf("endEvent_membershipDeclined"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -389,17 +389,17 @@ object MiraveloMembershipProcessApi {
 
     val SERVICE_TASK_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
           name = "Send Confirmation Mail",
-          previousElements = listOf("startEvent_ConfirmationRequired"),
-          followingElements = listOf("userTask_ConfirmMembership"),
-          parentId = "subProcess_ConfirmMembership",
+          previousElements = listOf("startEvent_confirmationRequired"),
+          followingElements = listOf("userTask_confirmMembership"),
+          parentId = "subProcess_confirmMembership",
           attachedToRef = null,
           attachedElements = emptyList(),
         )
 
     val SERVICE_TASK_SEND_REJECTION_MAIL: BpmnRelations = BpmnRelations(
           name = "Send Rejection Mail",
-          previousElements = listOf("gateway_HasEmptySpots"),
-          followingElements = listOf("endEvent_MembershipRejected"),
+          previousElements = listOf("gateway_hasEmptySpots"),
+          followingElements = listOf("endEvent_membershipRejected"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -407,8 +407,8 @@ object MiraveloMembershipProcessApi {
 
     val SERVICE_TASK_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
           name = "Send Welcome Mail",
-          previousElements = listOf("subProcess_ConfirmMembership"),
-          followingElements = listOf("endEvent_MembershipActivated"),
+          previousElements = listOf("subProcess_confirmMembership"),
+          followingElements = listOf("endEvent_membershipActivated"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -417,8 +417,8 @@ object MiraveloMembershipProcessApi {
     val START_EVENT_CONFIRMATION_REQUIRED: BpmnRelations = BpmnRelations(
           name = "Confirmation required",
           previousElements = emptyList(),
-          followingElements = listOf("serviceTask_SendConfirmationMail"),
-          parentId = "subProcess_ConfirmMembership",
+          followingElements = listOf("serviceTask_sendConfirmationMail"),
+          parentId = "subProcess_confirmMembership",
           attachedToRef = null,
           attachedElements = emptyList(),
         )
@@ -426,7 +426,7 @@ object MiraveloMembershipProcessApi {
     val START_EVENT_MEMBERSHIP_REQUESTED: BpmnRelations = BpmnRelations(
           name = "Membership requested",
           previousElements = emptyList(),
-          followingElements = listOf("serviceTask_ClaimMembership"),
+          followingElements = listOf("serviceTask_claimMembership"),
           parentId = null,
           attachedToRef = null,
           attachedElements = emptyList(),
@@ -434,18 +434,18 @@ object MiraveloMembershipProcessApi {
 
     val SUB_PROCESS_CONFIRM_MEMBERSHIP: BpmnRelations = BpmnRelations(
           name = "Confirm Membership",
-          previousElements = listOf("gateway_HasEmptySpots"),
-          followingElements = listOf("serviceTask_SendWelcomeMail"),
+          previousElements = listOf("gateway_hasEmptySpots"),
+          followingElements = listOf("serviceTask_sendWelcomeMail"),
           parentId = null,
           attachedToRef = null,
-          attachedElements = listOf("event_ReminderDue", "event_ConfirmationRejected", "event_ConfirmationDeadlinePassed"),
+          attachedElements = listOf("event_reminderDue", "event_confirmationRejected", "event_confirmationDeadlinePassed"),
         )
 
     val USER_TASK_CONFIRM_MEMBERSHIP: BpmnRelations = BpmnRelations(
           name = "Confirm Membership",
-          previousElements = listOf("serviceTask_SendConfirmationMail"),
-          followingElements = listOf("endEvent_MembershipConfirmed"),
-          parentId = "subProcess_ConfirmMembership",
+          previousElements = listOf("serviceTask_sendConfirmationMail"),
+          followingElements = listOf("endEvent_membershipConfirmed"),
+          parentId = "subProcess_confirmMembership",
           attachedToRef = null,
           attachedElements = emptyList(),
         )

--- a/services/example-service/src/main/resources/bpmn/membership.bpmn
+++ b/services/example-service/src/main/resources/bpmn/membership.bpmn
@@ -12,277 +12,277 @@
   </bpmn:message>
   <bpmn:signal id="Signal_MembershipActivated" name="miravelo.membershipActivated" />
   <bpmn:process id="miravelo-membership" isExecutable="true">
-    <bpmn:startEvent id="startEvent_MembershipRequested" name="Membership&#10;requested">
+    <bpmn:startEvent id="startEvent_membershipRequested" name="Membership&#10;requested">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=membershipId" target="membershipId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_start_to_claim</bpmn:outgoing>
+      <bpmn:outgoing>flow_startToClaim</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_start" messageRef="Message_MembershipRequested" />
     </bpmn:startEvent>
-    <bpmn:serviceTask id="serviceTask_ClaimMembership" name="Claim Membership">
+    <bpmn:serviceTask id="serviceTask_claimMembership" name="Claim Membership">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.claimMembership" />
         <zeebe:ioMapping>
           <zeebe:output source="=hasEmptySpots" target="hasEmptySpots" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_start_to_claim</bpmn:incoming>
-      <bpmn:outgoing>Flow_claim_to_gateway</bpmn:outgoing>
+      <bpmn:incoming>flow_startToClaim</bpmn:incoming>
+      <bpmn:outgoing>flow_claimToGateway</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="gateway_HasEmptySpots" name="Has empty&#10;spots?" default="Flow_no_spots">
-      <bpmn:incoming>Flow_claim_to_gateway</bpmn:incoming>
-      <bpmn:outgoing>Flow_yes_spots</bpmn:outgoing>
-      <bpmn:outgoing>Flow_no_spots</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_hasEmptySpots" name="Has empty&#10;spots?" default="flow_noSpots">
+      <bpmn:incoming>flow_claimToGateway</bpmn:incoming>
+      <bpmn:outgoing>flow_yesSpots</bpmn:outgoing>
+      <bpmn:outgoing>flow_noSpots</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="subProcess_ConfirmMembership" name="Confirm Membership">
-      <bpmn:incoming>Flow_yes_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_subProcess_to_welcome</bpmn:outgoing>
-      <bpmn:startEvent id="startEvent_ConfirmationRequired" name="Confirmation&#10;required">
-        <bpmn:outgoing>Flow_subStart_to_confirmationMail</bpmn:outgoing>
+    <bpmn:subProcess id="subProcess_confirmMembership" name="Confirm Membership">
+      <bpmn:incoming>flow_yesSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_subProcessToWelcome</bpmn:outgoing>
+      <bpmn:startEvent id="startEvent_confirmationRequired" name="Confirmation&#10;required">
+        <bpmn:outgoing>flow_subStartToConfirmationMail</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="serviceTask_SendConfirmationMail" name="Send&#10;Confirmation Mail">
+      <bpmn:serviceTask id="serviceTask_sendConfirmationMail" name="Send&#10;Confirmation Mail">
         <bpmn:extensionElements>
           <zeebe:taskDefinition type="miravelo.sendConfirmationMail" />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_subStart_to_confirmationMail</bpmn:incoming>
-        <bpmn:outgoing>Flow_confirmationMail_to_userTask</bpmn:outgoing>
+        <bpmn:incoming>flow_subStartToConfirmationMail</bpmn:incoming>
+        <bpmn:outgoing>flow_confirmationMailToUserTask</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:userTask id="userTask_ConfirmMembership" name="Confirm Membership">
+      <bpmn:userTask id="userTask_confirmMembership" name="Confirm Membership">
         <bpmn:extensionElements>
           <zeebe:userTask />
         </bpmn:extensionElements>
-        <bpmn:incoming>Flow_confirmationMail_to_userTask</bpmn:incoming>
-        <bpmn:outgoing>Flow_userTask_to_subEnd</bpmn:outgoing>
+        <bpmn:incoming>flow_confirmationMailToUserTask</bpmn:incoming>
+        <bpmn:outgoing>flow_userTaskToSubEnd</bpmn:outgoing>
       </bpmn:userTask>
-      <bpmn:endEvent id="endEvent_MembershipConfirmed" name="Membership&#10;confirmed">
-        <bpmn:incoming>Flow_userTask_to_subEnd</bpmn:incoming>
+      <bpmn:endEvent id="endEvent_membershipConfirmed" name="Membership&#10;confirmed">
+        <bpmn:incoming>flow_userTaskToSubEnd</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_subStart_to_confirmationMail" sourceRef="startEvent_ConfirmationRequired" targetRef="serviceTask_SendConfirmationMail" />
-      <bpmn:sequenceFlow id="Flow_confirmationMail_to_userTask" sourceRef="serviceTask_SendConfirmationMail" targetRef="userTask_ConfirmMembership" />
-      <bpmn:sequenceFlow id="Flow_userTask_to_subEnd" sourceRef="userTask_ConfirmMembership" targetRef="endEvent_MembershipConfirmed" />
+      <bpmn:sequenceFlow id="flow_subStartToConfirmationMail" sourceRef="startEvent_confirmationRequired" targetRef="serviceTask_sendConfirmationMail" />
+      <bpmn:sequenceFlow id="flow_confirmationMailToUserTask" sourceRef="serviceTask_sendConfirmationMail" targetRef="userTask_confirmMembership" />
+      <bpmn:sequenceFlow id="flow_userTaskToSubEnd" sourceRef="userTask_confirmMembership" targetRef="endEvent_membershipConfirmed" />
     </bpmn:subProcess>
-    <bpmn:serviceTask id="serviceTask_SendWelcomeMail" name="Send&#10;Welcome Mail">
+    <bpmn:serviceTask id="serviceTask_sendWelcomeMail" name="Send&#10;Welcome Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendWelcomeMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_subProcess_to_welcome</bpmn:incoming>
-      <bpmn:outgoing>Flow_welcome_to_activated</bpmn:outgoing>
+      <bpmn:incoming>flow_subProcessToWelcome</bpmn:incoming>
+      <bpmn:outgoing>flow_welcomeToActivated</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipActivated" name="Membership&#10;activated">
-      <bpmn:incoming>Flow_welcome_to_activated</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipActivated" name="Membership&#10;activated">
+      <bpmn:incoming>flow_welcomeToActivated</bpmn:incoming>
       <bpmn:signalEventDefinition id="SignalEventDefinition_activated" signalRef="Signal_MembershipActivated" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_SendRejectionMail" name="Send Rejection Mail">
+    <bpmn:serviceTask id="serviceTask_sendRejectionMail" name="Send Rejection Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.sendRejectionMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_no_spots</bpmn:incoming>
-      <bpmn:outgoing>Flow_rejection_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_noSpots</bpmn:incoming>
+      <bpmn:outgoing>flow_rejectionToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipRejected" name="Membership&#10;rejected">
-      <bpmn:incoming>Flow_rejection_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipRejected" name="Membership&#10;rejected">
+      <bpmn:incoming>flow_rejectionToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ReminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timer_to_reSend</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_reminderDue" name="Reminder&#10;due" cancelActivity="false" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timerToReSend</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_resend">
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:serviceTask id="serviceTask_ReSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
+    <bpmn:serviceTask id="serviceTask_reSendConfirmationMail" name="Re-Send&#10;Confirmation Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.reSendConfirmationMail" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_timer_to_reSend</bpmn:incoming>
-      <bpmn:outgoing>Flow_reSend_to_end</bpmn:outgoing>
+      <bpmn:incoming>flow_timerToReSend</bpmn:incoming>
+      <bpmn:outgoing>flow_reSendToEnd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MailSentAgain" name="Mail sent&#10;again">
-      <bpmn:incoming>Flow_reSend_to_end</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_mailSentAgain" name="Mail sent&#10;again">
+      <bpmn:incoming>flow_reSendToEnd</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_rejected_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationRejected" name="Confirmation&#10;rejected" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_rejectedToRevoke</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_rejected" messageRef="Message_ConfirmationRejected" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="event_ConfirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_ConfirmMembership">
-      <bpmn:outgoing>Flow_timeout_to_revoke</bpmn:outgoing>
+    <bpmn:boundaryEvent id="event_confirmationDeadlinePassed" name="Deadline&#10;passed" attachedToRef="subProcess_confirmMembership">
+      <bpmn:outgoing>flow_timeoutToRevoke</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_abort">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P3DT12H</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:exclusiveGateway id="gateway_RevokeReason">
-      <bpmn:incoming>Flow_timeout_to_revoke</bpmn:incoming>
-      <bpmn:incoming>Flow_rejected_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_gateway_to_revoke</bpmn:outgoing>
+    <bpmn:exclusiveGateway id="gateway_revokeReason">
+      <bpmn:incoming>flow_timeoutToRevoke</bpmn:incoming>
+      <bpmn:incoming>flow_rejectedToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_gatewayToRevoke</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="serviceTask_RevokeMembershipRequest" name="Revoke&#10;Membership Request">
+    <bpmn:serviceTask id="serviceTask_revokeMembershipRequest" name="Revoke&#10;Membership Request">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeMembershipRequest" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_gateway_to_revoke</bpmn:incoming>
-      <bpmn:outgoing>Flow_revoke_to_declined</bpmn:outgoing>
+      <bpmn:incoming>flow_gatewayToRevoke</bpmn:incoming>
+      <bpmn:outgoing>flow_revokeToDeclined</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="endEvent_MembershipDeclined" name="Membership&#10;declined">
-      <bpmn:incoming>Flow_revoke_to_declined</bpmn:incoming>
+    <bpmn:endEvent id="endEvent_membershipDeclined" name="Membership&#10;declined">
+      <bpmn:incoming>flow_revokeToDeclined</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_declined" />
     </bpmn:endEvent>
-    <bpmn:serviceTask id="serviceTask_RevokeClaim" name="Revoke Claim" isForCompensation="true">
+    <bpmn:serviceTask id="serviceTask_revokeClaim" name="Revoke Claim" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="miravelo.revokeClaim" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="event_ClaimCompensation" name="Claim made" attachedToRef="serviceTask_ClaimMembership">
+    <bpmn:boundaryEvent id="event_claimCompensation" name="Claim made" attachedToRef="serviceTask_claimMembership">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_claim" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_start_to_claim" sourceRef="startEvent_MembershipRequested" targetRef="serviceTask_ClaimMembership" />
-    <bpmn:sequenceFlow id="Flow_claim_to_gateway" sourceRef="serviceTask_ClaimMembership" targetRef="gateway_HasEmptySpots" />
-    <bpmn:sequenceFlow id="Flow_yes_spots" name="Yes" sourceRef="gateway_HasEmptySpots" targetRef="subProcess_ConfirmMembership">
+    <bpmn:sequenceFlow id="flow_startToClaim" sourceRef="startEvent_membershipRequested" targetRef="serviceTask_claimMembership" />
+    <bpmn:sequenceFlow id="flow_claimToGateway" sourceRef="serviceTask_claimMembership" targetRef="gateway_hasEmptySpots" />
+    <bpmn:sequenceFlow id="flow_yesSpots" name="Yes" sourceRef="gateway_hasEmptySpots" targetRef="subProcess_confirmMembership">
       <bpmn:conditionExpression>=hasEmptySpots</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_no_spots" name="No" sourceRef="gateway_HasEmptySpots" targetRef="serviceTask_SendRejectionMail" />
-    <bpmn:sequenceFlow id="Flow_subProcess_to_welcome" sourceRef="subProcess_ConfirmMembership" targetRef="serviceTask_SendWelcomeMail" />
-    <bpmn:sequenceFlow id="Flow_welcome_to_activated" sourceRef="serviceTask_SendWelcomeMail" targetRef="endEvent_MembershipActivated" />
-    <bpmn:sequenceFlow id="Flow_rejection_to_end" sourceRef="serviceTask_SendRejectionMail" targetRef="endEvent_MembershipRejected" />
-    <bpmn:sequenceFlow id="Flow_timer_to_reSend" sourceRef="event_ReminderDue" targetRef="serviceTask_ReSendConfirmationMail" />
-    <bpmn:sequenceFlow id="Flow_reSend_to_end" sourceRef="serviceTask_ReSendConfirmationMail" targetRef="endEvent_MailSentAgain" />
-    <bpmn:sequenceFlow id="Flow_timeout_to_revoke" sourceRef="event_ConfirmationDeadlinePassed" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_rejected_to_revoke" sourceRef="event_ConfirmationRejected" targetRef="gateway_RevokeReason" />
-    <bpmn:sequenceFlow id="Flow_gateway_to_revoke" sourceRef="gateway_RevokeReason" targetRef="serviceTask_RevokeMembershipRequest" />
-    <bpmn:sequenceFlow id="Flow_revoke_to_declined" sourceRef="serviceTask_RevokeMembershipRequest" targetRef="endEvent_MembershipDeclined" />
-    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_ClaimCompensation" targetRef="serviceTask_RevokeClaim" />
+    <bpmn:sequenceFlow id="flow_noSpots" name="No" sourceRef="gateway_hasEmptySpots" targetRef="serviceTask_sendRejectionMail" />
+    <bpmn:sequenceFlow id="flow_subProcessToWelcome" sourceRef="subProcess_confirmMembership" targetRef="serviceTask_sendWelcomeMail" />
+    <bpmn:sequenceFlow id="flow_welcomeToActivated" sourceRef="serviceTask_sendWelcomeMail" targetRef="endEvent_membershipActivated" />
+    <bpmn:sequenceFlow id="flow_rejectionToEnd" sourceRef="serviceTask_sendRejectionMail" targetRef="endEvent_membershipRejected" />
+    <bpmn:sequenceFlow id="flow_timerToReSend" sourceRef="event_reminderDue" targetRef="serviceTask_reSendConfirmationMail" />
+    <bpmn:sequenceFlow id="flow_reSendToEnd" sourceRef="serviceTask_reSendConfirmationMail" targetRef="endEvent_mailSentAgain" />
+    <bpmn:sequenceFlow id="flow_timeoutToRevoke" sourceRef="event_confirmationDeadlinePassed" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_rejectedToRevoke" sourceRef="event_confirmationRejected" targetRef="gateway_revokeReason" />
+    <bpmn:sequenceFlow id="flow_gatewayToRevoke" sourceRef="gateway_revokeReason" targetRef="serviceTask_revokeMembershipRequest" />
+    <bpmn:sequenceFlow id="flow_revokeToDeclined" sourceRef="serviceTask_revokeMembershipRequest" targetRef="endEvent_membershipDeclined" />
+    <bpmn:association id="Association_ClaimCompensation" associationDirection="One" sourceRef="event_claimCompensation" targetRef="serviceTask_revokeClaim" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="miravelo-membership">
-      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_MembershipRequested">
+      <bpmndi:BPMNShape id="Event_start_di" bpmnElement="startEvent_membershipRequested">
         <dc:Bounds x="172" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="355" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_ClaimMembership">
+      <bpmndi:BPMNShape id="Activity_claim_di" bpmnElement="serviceTask_claimMembership">
         <dc:Bounds x="270" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_HasEmptySpots" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_spots_di" bpmnElement="gateway_hasEmptySpots" isMarkerVisible="true">
         <dc:Bounds x="425" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="275" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_ConfirmMembership" isExpanded="true">
+      <bpmndi:BPMNShape id="SubProcess_confirm_di" bpmnElement="subProcess_confirmMembership" isExpanded="true">
         <dc:Bounds x="540" y="230" width="520" height="210" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_ConfirmationRequired">
+      <bpmndi:BPMNShape id="Event_subStart_di" bpmnElement="startEvent_confirmationRequired">
         <dc:Bounds x="582" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="569" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_SendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_sendConfirmation_di" bpmnElement="serviceTask_sendConfirmationMail">
         <dc:Bounds x="670" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_ConfirmMembership">
+      <bpmndi:BPMNShape id="Activity_userTask_di" bpmnElement="userTask_confirmMembership">
         <dc:Bounds x="810" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_MembershipConfirmed">
+      <bpmndi:BPMNShape id="Event_subEnd_di" bpmnElement="endEvent_membershipConfirmed">
         <dc:Bounds x="972" y="315" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="959" y="358" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_subStart_to_confirmationMail_di" bpmnElement="Flow_subStart_to_confirmationMail">
+      <bpmndi:BPMNEdge id="flow_subStartToConfirmationMail_di" bpmnElement="flow_subStartToConfirmationMail">
         <di:waypoint x="618" y="333" />
         <di:waypoint x="670" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_confirmationMail_to_userTask_di" bpmnElement="Flow_confirmationMail_to_userTask">
+      <bpmndi:BPMNEdge id="flow_confirmationMailToUserTask_di" bpmnElement="flow_confirmationMailToUserTask">
         <di:waypoint x="770" y="333" />
         <di:waypoint x="810" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_userTask_to_subEnd_di" bpmnElement="Flow_userTask_to_subEnd">
+      <bpmndi:BPMNEdge id="flow_userTaskToSubEnd_di" bpmnElement="flow_userTaskToSubEnd">
         <di:waypoint x="910" y="333" />
         <di:waypoint x="972" y="333" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_SendWelcomeMail">
+      <bpmndi:BPMNShape id="Activity_welcome_di" bpmnElement="serviceTask_sendWelcomeMail">
         <dc:Bounds x="1110" y="290" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_MembershipActivated">
+      <bpmndi:BPMNShape id="Event_activated_di" bpmnElement="endEvent_membershipActivated">
         <dc:Bounds x="1262" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="355" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_SendRejectionMail">
+      <bpmndi:BPMNShape id="Activity_rejection_di" bpmnElement="serviceTask_sendRejectionMail">
         <dc:Bounds x="540" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_MembershipRejected">
+      <bpmndi:BPMNShape id="Event_rejected_di" bpmnElement="endEvent_membershipRejected">
         <dc:Bounds x="702" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="575" width="61" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_ReSendConfirmationMail">
+      <bpmndi:BPMNShape id="Activity_reSend_di" bpmnElement="serviceTask_reSendConfirmationMail">
         <dc:Bounds x="1110" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_MailSentAgain">
+      <bpmndi:BPMNShape id="Event_mailSentAgain_di" bpmnElement="endEvent_mailSentAgain">
         <dc:Bounds x="1262" y="532" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1252" y="575" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_RevokeReason" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_revokeReason_di" bpmnElement="gateway_revokeReason" isMarkerVisible="true">
         <dc:Bounds x="1015" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_RevokeMembershipRequest">
+      <bpmndi:BPMNShape id="Activity_revokeRequest_di" bpmnElement="serviceTask_revokeMembershipRequest">
         <dc:Bounds x="1100" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_MembershipDeclined">
+      <bpmndi:BPMNShape id="Event_declined_di" bpmnElement="endEvent_membershipDeclined">
         <dc:Bounds x="1262" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1251" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_RevokeClaim">
+      <bpmndi:BPMNShape id="Activity_revokeClaim_di" bpmnElement="serviceTask_revokeClaim">
         <dc:Bounds x="400" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_ClaimCompensation">
+      <bpmndi:BPMNShape id="Event_claimCompensation_di" bpmnElement="event_claimCompensation">
         <dc:Bounds x="312" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="250" y="244" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_ConfirmationDeadlinePassed">
+      <bpmndi:BPMNShape id="Event_abort_di" bpmnElement="event_confirmationDeadlinePassed">
         <dc:Bounds x="972" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="186" width="42" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_ConfirmationRejected">
+      <bpmndi:BPMNShape id="Event_confirmationRejected_di" bpmnElement="event_confirmationRejected">
         <dc:Bounds x="702" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="638" y="186" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_ReminderDue">
+      <bpmndi:BPMNShape id="Event_resendEveryDay_di" bpmnElement="event_reminderDue">
         <dc:Bounds x="972" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1005" y="465" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_start_to_claim_di" bpmnElement="Flow_start_to_claim">
+      <bpmndi:BPMNEdge id="flow_startToClaim_di" bpmnElement="flow_startToClaim">
         <di:waypoint x="208" y="330" />
         <di:waypoint x="270" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_claim_to_gateway_di" bpmnElement="Flow_claim_to_gateway">
+      <bpmndi:BPMNEdge id="flow_claimToGateway_di" bpmnElement="flow_claimToGateway">
         <di:waypoint x="370" y="330" />
         <di:waypoint x="425" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_yes_spots_di" bpmnElement="Flow_yes_spots">
+      <bpmndi:BPMNEdge id="flow_yesSpots_di" bpmnElement="flow_yesSpots">
         <di:waypoint x="475" y="330" />
         <di:waypoint x="540" y="330" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="499" y="312" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_no_spots_di" bpmnElement="Flow_no_spots">
+      <bpmndi:BPMNEdge id="flow_noSpots_di" bpmnElement="flow_noSpots">
         <di:waypoint x="450" y="355" />
         <di:waypoint x="450" y="550" />
         <di:waypoint x="540" y="550" />
@@ -290,42 +290,42 @@
           <dc:Bounds x="458" y="391" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_subProcess_to_welcome_di" bpmnElement="Flow_subProcess_to_welcome">
+      <bpmndi:BPMNEdge id="flow_subProcessToWelcome_di" bpmnElement="flow_subProcessToWelcome">
         <di:waypoint x="1060" y="330" />
         <di:waypoint x="1110" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_welcome_to_activated_di" bpmnElement="Flow_welcome_to_activated">
+      <bpmndi:BPMNEdge id="flow_welcomeToActivated_di" bpmnElement="flow_welcomeToActivated">
         <di:waypoint x="1210" y="330" />
         <di:waypoint x="1262" y="330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejection_to_end_di" bpmnElement="Flow_rejection_to_end">
+      <bpmndi:BPMNEdge id="flow_rejectionToEnd_di" bpmnElement="flow_rejectionToEnd">
         <di:waypoint x="640" y="550" />
         <di:waypoint x="702" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timer_to_reSend_di" bpmnElement="Flow_timer_to_reSend">
+      <bpmndi:BPMNEdge id="flow_timerToReSend_di" bpmnElement="flow_timerToReSend">
         <di:waypoint x="990" y="458" />
         <di:waypoint x="990" y="550" />
         <di:waypoint x="1110" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_reSend_to_end_di" bpmnElement="Flow_reSend_to_end">
+      <bpmndi:BPMNEdge id="flow_reSendToEnd_di" bpmnElement="flow_reSendToEnd">
         <di:waypoint x="1210" y="550" />
         <di:waypoint x="1262" y="550" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_timeout_to_revoke_di" bpmnElement="Flow_timeout_to_revoke">
+      <bpmndi:BPMNEdge id="flow_timeoutToRevoke_di" bpmnElement="flow_timeoutToRevoke">
         <di:waypoint x="990" y="212" />
         <di:waypoint x="990" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_rejected_to_revoke_di" bpmnElement="Flow_rejected_to_revoke">
+      <bpmndi:BPMNEdge id="flow_rejectedToRevoke_di" bpmnElement="flow_rejectedToRevoke">
         <di:waypoint x="720" y="212" />
         <di:waypoint x="720" y="120" />
         <di:waypoint x="1015" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_gateway_to_revoke_di" bpmnElement="Flow_gateway_to_revoke">
+      <bpmndi:BPMNEdge id="flow_gatewayToRevoke_di" bpmnElement="flow_gatewayToRevoke">
         <di:waypoint x="1065" y="120" />
         <di:waypoint x="1100" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_revoke_to_declined_di" bpmnElement="Flow_revoke_to_declined">
+      <bpmndi:BPMNEdge id="flow_revokeToDeclined_di" bpmnElement="flow_revokeToDeclined">
         <di:waypoint x="1200" y="120" />
         <di:waypoint x="1262" y="120" />
       </bpmndi:BPMNEdge>

--- a/tools/.bpmnlintrc
+++ b/tools/.bpmnlintrc
@@ -6,6 +6,9 @@
     "no-implicit-split": "error",
     "no-overlapping-elements": "error",
     "local/no-crossing-flows": "error",
-    "local/flow-through-element": "error"
+    "local/flow-through-element": "error",
+    "local/element-id": "error",
+    "local/message-id": "error",
+    "local/task-type": "error"
   }
 }

--- a/tools/bpmnlint-plugin-local/README.md
+++ b/tools/bpmnlint-plugin-local/README.md
@@ -1,7 +1,14 @@
 # bpmnlint-plugin-local
 
-In-repo [bpmnlint](https://github.com/bpmn-io/bpmnlint) plugin with deterministic **BPMN
-layout** rules. Part of the project's BPMN quality gates — see
+In-repo [bpmnlint](https://github.com/bpmn-io/bpmnlint) plugin with two rule families:
+
+- **Layout** — deterministic geometry rules computed over the diagram interchange (DI), closing
+  a blind spot in bpmnlint core (see below).
+- **Styleguide** — the ID and name conventions from
+  [`docs/bpmn-styleguide/styleguide.md`](../../docs/bpmn-styleguide/styleguide.md), so a
+  mismatched element id or Zeebe task type is caught before it reaches `bpmn-to-code` or the engine.
+
+Part of the project's BPMN quality gates — see
 [`docs/bpmn-quality-gates/`](../../docs/bpmn-quality-gates/) for the full story and the probes.
 
 ## Why this exists
@@ -27,10 +34,20 @@ missing geometric rules ourselves. They compute purely over the DI (shape `dc:Bo
 
 ## The rules
 
+### Layout (geometry over the DI)
+
 | Rule                         | Default | Detects                                                                                                    |
 | ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
 | `local/flow-through-element` | error   | a sequence flow whose drawn path enters the interior of a shape it does not connect to                     |
 | `local/no-crossing-flows`    | error   | two sequence flows whose drawn paths cross (flows that share a node are expected to meet and are excluded) |
+
+### Styleguide (ID & name conventions)
+
+| Rule                | Default | Detects                                                                                                                            |
+| ------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `local/element-id`  | error   | an element id that does not read `<type>_<CamelCaseName>` across the executable set — every event, task and gateway kind, sub-processes, call activities, transactions, ad-hoc sub-processes and sequence flows. A type may accept a sensible specific prefix **or** the generic one (boundary event: `boundary_` or `event_`; transaction/ad-hoc: their prefix or `subProcess_`). Events may further qualify with their event definition (`messageStartEvent_`, `messageBoundary_`, …); a qualifier that is **present but false** — e.g. `timerStartEvent_` on a message start event — is reported as a contradiction. Non-executable elements (text annotations, groups, associations, data objects/stores, pools/lanes) are not checked. |
+| `local/message-id`  | error   | a `bpmn:Message` **name** (the correlation key, not the `Message_<hash>` id) that does not read `<serviceName>.<state>`, both camelCase |
+| `local/task-type`   | error   | a service task's Zeebe **task type** (`zeebe:taskDefinition type=…`) that does not read `<serviceName>.<elementIdWithoutTypePrefix>`, both camelCase |
 
 ## How it is wired (no npm publish)
 
@@ -44,7 +61,10 @@ This package is **not** published. It is consumed locally:
    ```json
    "rules": {
      "local/no-crossing-flows": "error",
-     "local/flow-through-element": "error"
+     "local/flow-through-element": "error",
+     "local/element-id": "error",
+     "local/message-id": "error",
+     "local/task-type": "error"
    }
    ```
 
@@ -78,6 +98,9 @@ message-flow/association routing, and cross-pool crossings within a single colla
 ```
 index.js                      rule registry (maps local/<name> -> ./rules/<name>)
 rules/_geometry.js            shared DI extraction + segment/rect geometry
-rules/no-crossing-flows.js    local/no-crossing-flows
-rules/flow-through-element.js local/flow-through-element
+rules/no-crossing-flows.js    local/no-crossing-flows    (layout)
+rules/flow-through-element.js local/flow-through-element (layout)
+rules/element-id.js           local/element-id           (styleguide)
+rules/message-id.js           local/message-id           (styleguide)
+rules/task-type.js            local/task-type            (styleguide)
 ```

--- a/tools/bpmnlint-plugin-local/index.js
+++ b/tools/bpmnlint-plugin-local/index.js
@@ -1,14 +1,19 @@
 'use strict';
 
-// In-repo bpmnlint plugin: deterministic BPMN layout rules computed from the
-// diagram interchange (shape bounds + edge waypoints). These close the gap left
-// by core's no-overlapping-elements, which only compares shape-vs-shape bounds.
+// In-repo bpmnlint plugin. Two rule families, both wired into tools/.bpmnlintrc as a
+// `file:` devDependency so they run under the same `npm --prefix tools run lint:bpmn` gate —
+// no npm publishing required.
 //
-// Wired into tools/.bpmnlintrc as a `file:` devDependency, so it runs under the
-// same `npm --prefix tools run lint:bpmn` gate — no npm publishing required.
+// - Geometry rules computed from the diagram interchange (shape bounds + edge waypoints),
+//   closing the gap left by core's no-overlapping-elements (shape-vs-shape bounds only).
+// - Styleguide rules enforcing the ID/name conventions from docs/bpmn-styleguide/styleguide.md
+//   (element ids, message names, Zeebe task types).
 module.exports = {
   rules: {
     'no-crossing-flows': './rules/no-crossing-flows',
     'flow-through-element': './rules/flow-through-element',
+    'element-id': './rules/element-id',
+    'message-id': './rules/message-id',
+    'task-type': './rules/task-type',
   },
 };

--- a/tools/bpmnlint-plugin-local/package.json
+++ b/tools/bpmnlint-plugin-local/package.json
@@ -2,6 +2,6 @@
   "name": "bpmnlint-plugin-local",
   "version": "1.0.0",
   "private": true,
-  "description": "In-repo bpmnlint rules for deterministic BPMN layout checks (crossing flows, flows routed through shapes).",
+  "description": "In-repo bpmnlint rules: deterministic BPMN layout checks (crossing flows, flows routed through shapes) plus styleguide ID/name conventions (element ids, message names, Zeebe task types).",
   "main": "index.js"
 }

--- a/tools/bpmnlint-plugin-local/rules/element-id.js
+++ b/tools/bpmnlint-plugin-local/rules/element-id.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Styleguide "Element IDs": every automation-relevant element carries an id of the form
+ * `<type>_<name>`, both `<type>` and `<name>` in lowerCamelCase — so the whole id reads as one
+ * camelCase token with an underscore separating the type from the name (e.g. `flow_noSpots`,
+ * `serviceTask_sendWelcomeMail`). See docs/bpmn-styleguide/styleguide.md.
+ *
+ * Coverage is the executable set: every event, task and gateway kind, sub-processes, call
+ * activities, transactions, ad-hoc sub-processes and sequence flows. Non-executable elements
+ * Zeebe ignores — text annotations, groups, associations, data objects/stores, pools/lanes —
+ * are deliberately skipped: their ids are auto-generated and carry no automation meaning, so the
+ * rule never fires on an element the styleguide has no opinion about.
+ *
+ * A type may accept MORE THAN ONE base prefix — a sensible specific one and the normal generic
+ * one, both valid. A boundary event may read `boundary_` or `event_`; a transaction or ad-hoc
+ * sub-process may read its specific prefix or the generic `subProcess_`.
+ *
+ * Events may additionally qualify a prefix with their event definition (`timerStartEvent_`,
+ * `messageBoundary_`, ...). That qualifier is optional, but one that IS present must be true: a
+ * `timerStartEvent_` on a message start event is a finding, because an id that lies about the
+ * model is worse than one that stays silent about it.
+ */
+const PREFIX_BY_TYPE = {
+  'bpmn:StartEvent': 'startEvent',
+  'bpmn:IntermediateCatchEvent': 'event',
+  'bpmn:IntermediateThrowEvent': 'event',
+  'bpmn:EndEvent': 'endEvent',
+  'bpmn:BoundaryEvent': ['event', 'boundary'],
+  'bpmn:Task': 'task',
+  'bpmn:ServiceTask': 'serviceTask',
+  'bpmn:UserTask': 'userTask',
+  'bpmn:SendTask': 'sendTask',
+  'bpmn:ReceiveTask': 'receiveTask',
+  'bpmn:ManualTask': 'manualTask',
+  'bpmn:ScriptTask': 'scriptTask',
+  'bpmn:BusinessRuleTask': 'businessRuleTask',
+  'bpmn:ExclusiveGateway': 'gateway',
+  'bpmn:ParallelGateway': 'gateway',
+  'bpmn:InclusiveGateway': 'gateway',
+  'bpmn:EventBasedGateway': 'gateway',
+  'bpmn:ComplexGateway': 'gateway',
+  'bpmn:SubProcess': 'subProcess',
+  'bpmn:Transaction': ['subProcess', 'transaction'],
+  'bpmn:AdHocSubProcess': ['subProcess', 'adHocSubProcess'],
+  'bpmn:CallActivity': 'callActivity',
+  'bpmn:SequenceFlow': 'flow',
+};
+
+/**
+ * Every qualifier the styleguide knows, so that a wrong one is reported as a contradiction
+ * rather than silently accepted as part of the Name.
+ */
+const QUALIFIERS = [
+  'message',
+  'timer',
+  'signal',
+  'conditional',
+  'escalation',
+  'error',
+  'link',
+  'terminate',
+  'compensate',
+];
+
+function qualifiersOf(node) {
+  return (node.eventDefinitions || [])
+    .map((definition) => /^bpmn:(\w+)EventDefinition$/.exec(definition.$type))
+    .filter(Boolean)
+    .map((match) => match[1].toLowerCase());
+}
+
+function qualify(qualifier, prefix) {
+  return qualifier + prefix.charAt(0).toUpperCase() + prefix.slice(1);
+}
+
+/**
+ * @type { import('bpmnlint').RuleFactory }
+ */
+module.exports = function () {
+  function check(node, reporter) {
+    const mapping = PREFIX_BY_TYPE[node.$type];
+
+    if (!mapping || !node.id) {
+      return;
+    }
+
+    const bases = [].concat(mapping);
+    const qualifiers = qualifiersOf(node);
+    const allowed = bases.flatMap((base) => [base].concat(qualifiers.map((qualifier) => qualify(qualifier, base))));
+
+    if (allowed.some((candidate) => new RegExp(`^${candidate}_[a-z][A-Za-z0-9]*$`).test(node.id))) {
+      return;
+    }
+
+    const claimed = QUALIFIERS.find((qualifier) =>
+      bases.some((base) => node.id.startsWith(qualify(qualifier, base) + '_')),
+    );
+
+    if (claimed) {
+      reporter.report(
+        node.id,
+        `Element id ${node.id} claims to be a ${claimed} event, but the element has no ${claimed} event definition`,
+      );
+      return;
+    }
+
+    reporter.report(node.id, `Element id ${node.id} should read <${allowed.join('|')}>_<camelCaseName>`);
+  }
+
+  return { check };
+};

--- a/tools/bpmnlint-plugin-local/rules/message-id.js
+++ b/tools/bpmnlint-plugin-local/rules/message-id.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { is } = require('bpmnlint-utils');
+
+/**
+ * Styleguide "Message IDs": `<serviceName>.<state>`, both parts in camelCase (see
+ * docs/bpmn-styleguide/styleguide.md).
+ *
+ * The correlation key is the message *name*, not the `Message_<hash>` id the modeler
+ * generates — so that is what this rule checks. A message without a name is left alone.
+ */
+const MESSAGE_NAME = /^[a-z][A-Za-z0-9]*\.[a-z][A-Za-z0-9]*$/;
+
+/**
+ * @type { import('bpmnlint').RuleFactory }
+ */
+module.exports = function () {
+  function check(node, reporter) {
+    if (!is(node, 'bpmn:Message') || !node.name) {
+      return;
+    }
+
+    if (!MESSAGE_NAME.test(node.name)) {
+      reporter.report(node.id, `Message name <${node.name}> should read <serviceName.myCamelCaseState>`);
+    }
+  }
+
+  return { check };
+};

--- a/tools/bpmnlint-plugin-local/rules/task-type.js
+++ b/tools/bpmnlint-plugin-local/rules/task-type.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { is } = require('bpmnlint-utils');
+
+/**
+ * Styleguide "Worker IDs" (a.k.a. type ids / job types): a service task's Zeebe task type reads
+ * `<serviceName>.<elementIdWithoutTypePrefix>`, both parts in camelCase (see
+ * docs/bpmn-styleguide/styleguide.md).
+ *
+ * The type lives on `<zeebe:taskDefinition type="...">` inside the task's extensionElements.
+ * bpmn-moddle parses that unknown element generically, exposing the attribute as `.type` (with
+ * a `$attrs` fallback for safety). A service task with no task definition is left alone.
+ */
+const TASK_TYPE = /^[a-z][A-Za-z0-9]*\.[a-z][A-Za-z0-9]*$/;
+
+function taskTypeOf(node) {
+  const extension = node.extensionElements;
+  const definition =
+    extension && extension.values && extension.values.find((value) => value.$type === 'zeebe:taskDefinition');
+
+  if (!definition) {
+    return null;
+  }
+
+  return definition.type || (definition.$attrs || {})['type'] || null;
+}
+
+/**
+ * @type { import('bpmnlint').RuleFactory }
+ */
+module.exports = function () {
+  function check(node, reporter) {
+    if (!is(node, 'bpmn:ServiceTask')) {
+      return;
+    }
+
+    const type = taskTypeOf(node);
+
+    if (!type) {
+      return;
+    }
+
+    if (!TASK_TYPE.test(type)) {
+      reporter.report(node.id, `Task type <${type}> should read <serviceName.myCamelCaseTopic> (styleguide: Worker IDs)`);
+    }
+  }
+
+  return { check };
+};


### PR DESCRIPTION
## Why

BPMN ID and name conventions were documented in the styleguide but not machine-checked, so auto-generated ids and inconsistent casing could slip in and break `bpmn-to-code` generation.

## What

- Three in-repo bpmnlint rules (`tools/bpmnlint-plugin-local/rules/`): `element-id` (every executable element reads `type_name` in lowerCamelCase — all event/task/gateway kinds, sub-processes, call activities, sequence flows; boundary events accept `boundary_` or `event_`, plus an optional-but-truthful event-definition qualifier), `message-id` (`service.state`), and `task-type` (Zeebe `zeebe:taskDefinition` reads `service.topic`) — all wired into the existing `npm --prefix tools run lint:bpmn` gate (pre-commit + CI).
- Expanded `docs/bpmn-styleguide/styleguide.md` with the full element-ID table and the lowerCamelCase rule.
- Migrated `membership.bpmn` and the four lint probes to lowerCamelCase `type_name` ids and regenerated the ProcessApi (constant names unchanged); updated probe READMEs and two skill examples.

No linked issue (#85 is a separate visual-verification feature). Lint is green and the unit suite passes; the Docker-backed process test wasn't run in this environment.
